### PR TITLE
ci: SuperLinter rather than individual linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,4 @@
+---
 name: Lint
 on:
   push:
@@ -9,6 +10,7 @@ on:
 
 jobs:
   action-linter:
+    name: Action Linter
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -16,8 +18,19 @@ jobs:
         with:
           workflows: '[".github/workflows/*.yml"]'
 
-  shellcheck:
+  repo-linter:
+    name: SuperLinter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: ludeeus/action-shellcheck@master
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v3
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As we begin to accept publicly contributed ingestion code, let's default to using [GitHub's SuperLinter](https://github.com/github/super-linter) rather than thinking through linting and formatting practices for each novel accepted language.

If we find this to be too aggressive, we can switch back to a known-desirable set of linters run in the action directly.