### PR TITLE
Framework for running runners for sites

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,6 +20,12 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 
+# Python
+[*.sh]
+charset = utf-8
+indent_style = space
+indent_size = 4
+
 # Makefile
 [Makefile]
 indent_style = tab

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,7 @@
     "python.pythonPath": ".venv/bin/python",
     "python.formatting.provider": "black",
     "python.linting.flake8Enabled": true,
-    "python.linting.mypyEnabled": true
+    "python.linting.mypyEnabled": true,
+    "python.linting.pylintEnabled": false,
+    "python.linting.enabled": true
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# vaccine-feed-ingest
+
+Pipeline for ingesting nationwide feed of vaccine facilities
+
+## Usage
+
+### Setup Environment Once
+
+1. Install required system deps (Ubuntu/Debian):
+
+    ```sh
+    sudo apt-get install libbz2-dev liblzma-dev libreadline-dev libsqlite3-dev
+    ```
+
+1. Install `pyenv`:
+
+    ```sh
+    curl https://pyenv.run | bash
+    ```
+
+1. Add to `.bashrc`:
+
+    ```sh
+    export PATH="/home/codespace/.pyenv/bin:$PATH"
+    eval "$(pyenv init -)"
+    eval "$(pyenv virtualenv-init -)"
+    ```
+
+1. Install project python version:
+
+    ```sh
+    pyenv install
+    ```
+
+1. Install `poetry`:
+
+    ```sh
+    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+    ```
+
+1. Add to `.bashrc`:
+
+    ```sh
+    export PATH="$HOME/.poetry/bin:$PATH"
+    ```
+
+1. Install app dependancies:
+
+    ```sh
+    poetry install
+    ```
+
+1. (optional) For development:
+
+    ```sh
+    poetry install --extras lint
+    ```

--- a/README.md
+++ b/README.md
@@ -55,3 +55,30 @@ Pipeline for ingesting nationwide feed of vaccine facilities
     ```sh
     poetry install --extras lint
     ```
+
+
+### Run Pipelines
+
+- List all available sites:
+
+    ```sh
+    poetry run vaccine-feed-ingest/run.py available-sites
+    ```
+
+- Run fetch for just one site:
+
+    ```sh
+    poetry run vaccine-feed-ingest/run.py fetch ca/sf_gov
+    ```
+
+- Run fetch for all sites in CA:
+
+    ```sh
+    poetry run vaccine-feed-ingest/run.py fetch --state=ca
+    ```
+
+- Run all stages for all sites:
+
+    ```sh
+    poetry run vaccine-feed-ingest/run.py all-stages
+    ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,306 @@
+[[package]]
+name = "appdirs"
+version = "1.4.4"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "main"
+optional = true
+python-versions = "*"
+
+[[package]]
+name = "black"
+version = "20.8b1"
+description = "The uncompromising code formatter."
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+appdirs = "*"
+click = ">=7.1.2"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.6,<1"
+regex = ">=2020.1.8"
+toml = ">=0.10.1"
+typed-ast = ">=1.4.0"
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
+
+[[package]]
+name = "click"
+version = "7.1.2"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "flake8"
+version = "3.9.0"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "main"
+optional = true
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.7.0,<2.8.0"
+pyflakes = ">=2.3.0,<2.4.0"
+
+[[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "main"
+optional = true
+python-versions = "*"
+
+[[package]]
+name = "mypy"
+version = "0.812"
+description = "Optional static typing for Python"
+category = "main"
+optional = true
+python-versions = ">=3.5"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3,<0.5.0"
+typed-ast = ">=1.4.0,<1.5.0"
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "main"
+optional = true
+python-versions = "*"
+
+[[package]]
+name = "pathspec"
+version = "0.8.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "main"
+optional = true
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pycodestyle"
+version = "2.7.0"
+description = "Python style guide checker"
+category = "main"
+optional = true
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyflakes"
+version = "2.3.1"
+description = "passive checker of Python programs"
+category = "main"
+optional = true
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "python-dotenv"
+version = "0.17.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
+name = "regex"
+version = "2021.4.4"
+description = "Alternative regular expression module, to replace re."
+category = "main"
+optional = true
+python-versions = "*"
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "main"
+optional = true
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "typed-ast"
+version = "1.4.2"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "main"
+optional = true
+python-versions = "*"
+
+[[package]]
+name = "typing-extensions"
+version = "3.7.4.3"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+category = "main"
+optional = true
+python-versions = "*"
+
+[extras]
+lint = ["flake8", "black", "mypy"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.9"
+content-hash = "e7c30d97c4aa254c3c97a65f1bbd76592e9c036b05536e95d7c47488e8a002e4"
+
+[metadata.files]
+appdirs = [
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+black = [
+    {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
+]
+click = [
+    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
+    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+]
+flake8 = [
+    {file = "flake8-3.9.0-py2.py3-none-any.whl", hash = "sha256:12d05ab02614b6aee8df7c36b97d1a3b2372761222b19b58621355e82acddcff"},
+    {file = "flake8-3.9.0.tar.gz", hash = "sha256:78873e372b12b093da7b5e5ed302e8ad9e988b38b063b61ad937f26ca58fc5f0"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+mypy = [
+    {file = "mypy-0.812-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:28fb5479c494b1bab244620685e2eb3c3f988d71fd5d64cc753195e8ed53df7c"},
+    {file = "mypy-0.812-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:9743c91088d396c1a5a3c9978354b61b0382b4e3c440ce83cf77994a43e8c521"},
+    {file = "mypy-0.812-cp35-cp35m-win_amd64.whl", hash = "sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb"},
+    {file = "mypy-0.812-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4eec37370483331d13514c3f55f446fc5248d6373e7029a29ecb7b7494851e7a"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c"},
+    {file = "mypy-0.812-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:61a3d5b97955422964be6b3baf05ff2ce7f26f52c85dd88db11d5e03e146a3a6"},
+    {file = "mypy-0.812-cp36-cp36m-win_amd64.whl", hash = "sha256:25adde9b862f8f9aac9d2d11971f226bd4c8fbaa89fb76bdadb267ef22d10064"},
+    {file = "mypy-0.812-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:552a815579aa1e995f39fd05dde6cd378e191b063f031f2acfe73ce9fb7f9e56"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:499c798053cdebcaa916eef8cd733e5584b5909f789de856b482cd7d069bdad8"},
+    {file = "mypy-0.812-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:5873888fff1c7cf5b71efbe80e0e73153fe9212fafdf8e44adfe4c20ec9f82d7"},
+    {file = "mypy-0.812-cp37-cp37m-win_amd64.whl", hash = "sha256:9f94aac67a2045ec719ffe6111df543bac7874cee01f41928f6969756e030564"},
+    {file = "mypy-0.812-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506"},
+    {file = "mypy-0.812-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:674e822aa665b9fd75130c6c5f5ed9564a38c6cea6a6432ce47eafb68ee578c5"},
+    {file = "mypy-0.812-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:abf7e0c3cf117c44d9285cc6128856106183938c68fd4944763003decdcfeb66"},
+    {file = "mypy-0.812-cp38-cp38-win_amd64.whl", hash = "sha256:0d0a87c0e7e3a9becdfbe936c981d32e5ee0ccda3e0f07e1ef2c3d1a817cf73e"},
+    {file = "mypy-0.812-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7ce3175801d0ae5fdfa79b4f0cfed08807af4d075b402b7e294e6aa72af9aa2a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b09669bcda124e83708f34a94606e01b614fa71931d356c1f1a5297ba11f110a"},
+    {file = "mypy-0.812-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:33f159443db0829d16f0a8d83d94df3109bb6dd801975fe86bacb9bf71628e97"},
+    {file = "mypy-0.812-cp39-cp39-win_amd64.whl", hash = "sha256:3f2aca7f68580dc2508289c729bd49ee929a436208d2b2b6aab15745a70a57df"},
+    {file = "mypy-0.812-py3-none-any.whl", hash = "sha256:2f9b3407c58347a452fc0736861593e105139b905cca7d097e413453a1d650b4"},
+    {file = "mypy-0.812.tar.gz", hash = "sha256:cd07039aa5df222037005b08fbbfd69b3ab0b0bd7a07d7906de75ae52c4e3119"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+pathspec = [
+    {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
+    {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
+    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+]
+pyflakes = [
+    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
+    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
+]
+python-dotenv = [
+    {file = "python-dotenv-0.17.0.tar.gz", hash = "sha256:471b782da0af10da1a80341e8438fca5fadeba2881c54360d5fd8d03d03a4f4a"},
+    {file = "python_dotenv-0.17.0-py2.py3-none-any.whl", hash = "sha256:49782a97c9d641e8a09ae1d9af0856cc587c8d2474919342d5104d85be9890b2"},
+]
+regex = [
+    {file = "regex-2021.4.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:619d71c59a78b84d7f18891fe914446d07edd48dc8328c8e149cbe0929b4e000"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:47bf5bf60cf04d72bf6055ae5927a0bd9016096bf3d742fa50d9bf9f45aa0711"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:281d2fd05555079448537fe108d79eb031b403dac622621c78944c235f3fcf11"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:bd28bc2e3a772acbb07787c6308e00d9626ff89e3bfcdebe87fa5afbfdedf968"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7c2a1af393fcc09e898beba5dd59196edaa3116191cc7257f9224beaed3e1aa0"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c38c71df845e2aabb7fb0b920d11a1b5ac8526005e533a8920aea97efb8ec6a4"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:96fcd1888ab4d03adfc9303a7b3c0bd78c5412b2bfbe76db5b56d9eae004907a"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:ade17eb5d643b7fead300a1641e9f45401c98eee23763e9ed66a43f92f20b4a7"},
+    {file = "regex-2021.4.4-cp36-cp36m-win32.whl", hash = "sha256:e8e5b509d5c2ff12f8418006d5a90e9436766133b564db0abaec92fd27fcee29"},
+    {file = "regex-2021.4.4-cp36-cp36m-win_amd64.whl", hash = "sha256:11d773d75fa650cd36f68d7ca936e3c7afaae41b863b8c387a22aaa78d3c5c79"},
+    {file = "regex-2021.4.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d3029c340cfbb3ac0a71798100ccc13b97dddf373a4ae56b6a72cf70dfd53bc8"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:18c071c3eb09c30a264879f0d310d37fe5d3a3111662438889ae2eb6fc570c31"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:4c557a7b470908b1712fe27fb1ef20772b78079808c87d20a90d051660b1d69a"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:01afaf2ec48e196ba91b37451aa353cb7eda77efe518e481707e0515025f0cd5"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:3a9cd17e6e5c7eb328517969e0cb0c3d31fd329298dd0c04af99ebf42e904f82"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:90f11ff637fe8798933fb29f5ae1148c978cccb0452005bf4c69e13db951e765"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:919859aa909429fb5aa9cf8807f6045592c85ef56fdd30a9a3747e513db2536e"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:339456e7d8c06dd36a22e451d58ef72cef293112b559010db3d054d5560ef439"},
+    {file = "regex-2021.4.4-cp37-cp37m-win32.whl", hash = "sha256:67bdb9702427ceddc6ef3dc382455e90f785af4c13d495f9626861763ee13f9d"},
+    {file = "regex-2021.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:32e65442138b7b76dd8173ffa2cf67356b7bc1768851dded39a7a13bf9223da3"},
+    {file = "regex-2021.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1e1c20e29358165242928c2de1482fb2cf4ea54a6a6dea2bd7a0e0d8ee321500"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:314d66636c494ed9c148a42731b3834496cc9a2c4251b1661e40936814542b14"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6d1b01031dedf2503631d0903cb563743f397ccaf6607a5e3b19a3d76fc10480"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:741a9647fcf2e45f3a1cf0e24f5e17febf3efe8d4ba1281dcc3aa0459ef424dc"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:4c46e22a0933dd783467cf32b3516299fb98cfebd895817d685130cc50cd1093"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e512d8ef5ad7b898cdb2d8ee1cb09a8339e4f8be706d27eaa180c2f177248a10"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:980d7be47c84979d9136328d882f67ec5e50008681d94ecc8afa8a65ed1f4a6f"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:ce15b6d103daff8e9fee13cf7f0add05245a05d866e73926c358e871221eae87"},
+    {file = "regex-2021.4.4-cp38-cp38-win32.whl", hash = "sha256:a91aa8619b23b79bcbeb37abe286f2f408d2f2d6f29a17237afda55bb54e7aac"},
+    {file = "regex-2021.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:c0502c0fadef0d23b128605d69b58edb2c681c25d44574fc673b0e52dce71ee2"},
+    {file = "regex-2021.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:598585c9f0af8374c28edd609eb291b5726d7cbce16be6a8b95aa074d252ee17"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:ee54ff27bf0afaf4c3b3a62bcd016c12c3fdb4ec4f413391a90bd38bc3624605"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7d9884d86dd4dd489e981d94a65cd30d6f07203d90e98f6f657f05170f6324c9"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:bf5824bfac591ddb2c1f0a5f4ab72da28994548c708d2191e3b87dd207eb3ad7"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:563085e55b0d4fb8f746f6a335893bda5c2cef43b2f0258fe1020ab1dd874df8"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9c3db21af35e3b3c05764461b262d6f05bbca08a71a7849fd79d47ba7bc33ed"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:3916d08be28a1149fb97f7728fca1f7c15d309a9f9682d89d79db75d5e52091c"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:fd45ff9293d9274c5008a2054ecef86a9bfe819a67c7be1afb65e69b405b3042"},
+    {file = "regex-2021.4.4-cp39-cp39-win32.whl", hash = "sha256:fa4537fb4a98fe8fde99626e4681cc644bdcf2a795038533f9f711513a862ae6"},
+    {file = "regex-2021.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:97f29f57d5b84e73fbaf99ab3e26134e6687348e95ef6b48cfd2c06807005a07"},
+    {file = "regex-2021.4.4.tar.gz", hash = "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7703620125e4fb79b64aa52427ec192822e9f45d37d4b6625ab37ef403e1df70"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c9aadc4924d4b5799112837b226160428524a9a45f830e0d0f184b19e4090487"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:9ec45db0c766f196ae629e509f059ff05fc3148f9ffd28f3cfe75d4afb485412"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win32.whl", hash = "sha256:85f95aa97a35bdb2f2f7d10ec5bbdac0aeb9dafdaf88e17492da0504de2e6400"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win_amd64.whl", hash = "sha256:9044ef2df88d7f33692ae3f18d3be63dec69c4fb1b5a4a9ac950f9b4ba571606"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c1c876fd795b36126f773db9cbb393f19808edd2637e00fd6caba0e25f2c7b64"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5dcfc2e264bd8a1db8b11a892bd1647154ce03eeba94b461effe68790d8b8e07"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8db0e856712f79c45956da0c9a40ca4246abc3485ae0d7ecc86a20f5e4c09abc"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d003156bb6a59cda9050e983441b7fa2487f7800d76bdc065566b7d728b4581a"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win32.whl", hash = "sha256:4c790331247081ea7c632a76d5b2a265e6d325ecd3179d06e9cf8d46d90dd151"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win_amd64.whl", hash = "sha256:d175297e9533d8d37437abc14e8a83cbc68af93cc9c1c59c2c292ec59a0697a3"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf54cfa843f297991b7388c281cb3855d911137223c6b6d2dd82a47ae5125a41"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b4fcdcfa302538f70929eb7b392f536a237cbe2ed9cba88e3bf5027b39f5f77f"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:987f15737aba2ab5f3928c617ccf1ce412e2e321c77ab16ca5a293e7bbffd581"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:37f48d46d733d57cc70fd5f30572d11ab8ed92da6e6b28e024e4a3edfb456e37"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:36d829b31ab67d6fcb30e185ec996e1f72b892255a745d3a82138c97d21ed1cd"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:8368f83e93c7156ccd40e49a783a6a6850ca25b556c0fa0240ed0f659d2fe496"},
+    {file = "typed_ast-1.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:963c80b583b0661918718b095e02303d8078950b26cc00b5e5ea9ababe0de1fc"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:84aa6223d71012c68d577c83f4e7db50d11d6b1399a9c779046d75e24bed74ea"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a38878a223bdd37c9709d07cd357bb79f4c760b29210e14ad0fb395294583787"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win32.whl", hash = "sha256:a2c927c49f2029291fbabd673d51a2180038f8cd5a5b2f290f78c4516be48be2"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:c0c74e5579af4b977c8b932f40a5464764b2f86681327410aa028a22d2f54937"},
+    {file = "typed_ast-1.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:07d49388d5bf7e863f7fa2f124b1b1d89d8aa0e2f7812faff0a5658c01c59aa1"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:240296b27397e4e37874abb1df2a608a92df85cf3e2a04d0d4d61055c8305ba6"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:14bf1522cdee369e8f5581238edac09150c765ec1cb33615855889cf33dcb92d"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win32.whl", hash = "sha256:cc7b98bf58167b7f2db91a4327da24fb93368838eb84a44c472283778fc2446b"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:7147e2a76c75f0f64c4319886e7639e490fee87c9d25cb1d4faef1d8cf83a440"},
+    {file = "typed_ast-1.4.2.tar.gz", hash = "sha256:9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
+    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
+    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+]

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,29 @@
+[tool.poetry]
+name = "vaccine-feed-ingest"
+version = "0.1.0"
+description = "Pipeline for ingesting nationwide feed of vaccine facilities"
+authors = ["Bryan Culbertson <bryan.culbertson@gmail.com>"]
+
+[tool.poetry.dependencies]
+flake8 = { version = "^3.9.0", optional = true }
+black = { version = "^20.8b1", optional = true }
+mypy = { version = "^0.812", optional = true }
+
+python = "^3.9"
+click = "^7.1.2"
+python-dotenv = "^0.17.0"
+
+[tool.poetry.dev-dependencies]
+
+[tool.poetry.extras]
+lint = ["flake8", "black", "mypy"]
+
+[tool.poetry.scripts]
+vaccine-feed-ingest = "vaccine-feed-ingest.run:cli"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.black]
 target-version = ['py38']

--- a/vaccine-feed-ingest/run.py
+++ b/vaccine-feed-ingest/run.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+"""
+Entry point for running vaccine feed runners
+"""
+import click
+import dotenv
+
+
+@click.group()
+def cli():
+    """Run vaccine-feed-ingest commands"""
+    pass
+
+
+@cli.command()
+def version():
+    """Get the library version."""
+    click.echo(click.style("0.1.0", bold=True))
+
+
+if __name__ == "__main__":
+    dotenv.load_dotenv()
+    cli()

--- a/vaccine-feed-ingest/run.py
+++ b/vaccine-feed-ingest/run.py
@@ -3,14 +3,161 @@
 """
 Entry point for running vaccine feed runners
 """
+import pathlib
+import subprocess
+import tempfile
+from typing import Iterator, Optional, Sequence
+
 import click
 import dotenv
+
+RUNNERS_DIR = pathlib.Path(__file__).parent / "runners"
+
+FETCH_CMD = "fetch.sh"
+PARSE_CMD = "parse.sh"
+NORMALIZE_CMD = "normalize.sh"
+
+
+def _get_site_dirs(state: Optional[str] = None) -> Iterator[pathlib.Path]:
+    """Return an iterator of site directory paths"""
+    for state_dir in RUNNERS_DIR.iterdir():
+        # Ignore private directories, in this case the _template directory
+        if state_dir.name.startswith("_"):
+            continue
+
+        if state and state_dir.name.lower() != state.lower():
+            continue
+
+        yield from state_dir.iterdir()
+
+
+def _get_site_dir(site: str) -> Optional[pathlib.Path]:
+    """Return a site directory path, if it exists"""
+    site_dir = RUNNERS_DIR / site
+
+    if site_dir.exists():
+        return site_dir
+
+
+def _run_fetch(site_dir: pathlib.Path) -> None:
+    fetch_path = site_dir / FETCH_CMD
+    if not fetch_path.exists():
+        return
+
+    with tempfile.TemporaryDirectory(f"_fetch_{site_dir.name}") as tmp_str:
+        tmp_dir = pathlib.Path(tmp_str)
+
+        subprocess.run([str(fetch_path), str(tmp_dir)], check=True)
+
+
+def _run_parse(site_dir: pathlib.Path) -> None:
+    parse_path = site_dir / PARSE_CMD
+    if not parse_path.exists():
+        return
+
+    with tempfile.TemporaryDirectory(f"_parse_{site_dir.name}") as tmp_str:
+        tmp_dir = pathlib.Path(tmp_str)
+
+        subprocess.run(
+            [str(parse_path), str(tmp_dir / "output"), str(tmp_dir / "input")],
+            check=True,
+        )
+
+
+def _run_normalize(site_dir: pathlib.Path) -> None:
+    normalize_path = site_dir / NORMALIZE_CMD
+    if not normalize_path.exists():
+        return
+
+    with tempfile.TemporaryDirectory(f"_normalize_{site_dir.name}") as tmp_str:
+        tmp_dir = pathlib.Path(tmp_str)
+
+        subprocess.run(
+            [str(normalize_path), str(tmp_dir / "output"), str(tmp_dir / "input")],
+            check=True,
+        )
 
 
 @click.group()
 def cli():
     """Run vaccine-feed-ingest commands"""
     pass
+
+
+@cli.command()
+@click.option("--state", "state", type=str)
+def available_sites(state: Optional[str]):
+    """Print list of available sites, optionally filtered by state"""
+
+    for site_dir in _get_site_dirs(state):
+        has_fetch = (site_dir / FETCH_CMD).exists()
+        has_parse = (site_dir / PARSE_CMD).exists()
+        has_normalize = (site_dir / NORMALIZE_CMD).exists()
+
+        print(
+            site_dir.relative_to(RUNNERS_DIR),
+            "fetch" if has_fetch else "no-fetch",
+            "parse" if has_parse else "no-parse",
+            "normalize" if has_normalize else "no-normalize",
+        )
+
+
+@cli.command()
+@click.option("--state", "state", type=str)
+@click.argument("sites", nargs=-1, type=str)
+def fetch(state: Optional[str], sites: Optional[Sequence[str]]):
+    """Run fetch process for specified sites."""
+    if not sites:
+        site_dirs = list(_get_site_dirs(state))
+    else:
+        site_dirs = [_get_site_dir(site) for site in sites]
+
+    for site_dir in site_dirs:
+        _run_fetch(site_dir)
+
+
+@cli.command()
+@click.option("--state", "state", type=str)
+@click.argument("sites", nargs=-1, type=str)
+def parse(state: Optional[str], sites: Optional[Sequence[str]]):
+    """Run parse process for specified sites."""
+    if not sites:
+        site_dirs = list(_get_site_dirs(state))
+    else:
+        site_dirs = [_get_site_dir(site) for site in sites]
+
+    for site_dir in site_dirs:
+        _run_parse(site_dir)
+
+
+@cli.command()
+@click.option("--state", "state", type=str)
+@click.argument("sites", nargs=-1, type=str)
+def normalize(state: Optional[str], sites: Optional[Sequence[str]]):
+    """Run normalize process for specified sites."""
+    if not sites:
+        site_dirs = list(_get_site_dirs(state))
+    else:
+        site_dirs = [_get_site_dir(site) for site in sites]
+
+    for site_dir in site_dirs:
+        _run_normalize(site_dir)
+
+
+@cli.command()
+@click.option("--state", "state", type=str)
+@click.argument("sites", nargs=-1, type=str)
+def all_stages(state: Optional[str], sites: Optional[Sequence[str]]):
+    """Run all stages in succession for specified sites."""
+    if not sites:
+        site_dirs = list(_get_site_dirs(state))
+    else:
+        site_dirs = [_get_site_dir(site) for site in sites]
+
+    for site_dir in site_dirs:
+        _run_fetch(site_dir)
+        _run_parse(site_dir)
+        _run_normalize(site_dir)
 
 
 @cli.command()

--- a/vaccine-feed-ingest/runners/_template/README.md
+++ b/vaccine-feed-ingest/runners/_template/README.md
@@ -1,0 +1,3 @@
+# Example Site
+
+To start a pipeline for a new site, start by copying this files in this directory to a new site.

--- a/vaccine-feed-ingest/runners/_template/fetch.sh
+++ b/vaccine-feed-ingest/runners/_template/fetch.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+output_dir=""
+
+if [ -n "${1}" ]; then
+    output_dir="${1}"
+else
+    echo "Must pass an output_dir as first argument"
+fi
+
+echo "Fetching into ${output_dir}"

--- a/vaccine-feed-ingest/runners/_template/normalize.sh
+++ b/vaccine-feed-ingest/runners/_template/normalize.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+output_dir=""
+input_dir=""
+
+if [ -n "${1}" ]; then
+    output_dir="${1}"
+else
+    echo "Must pass an output_dir as first argument"
+fi
+
+if [ -n "${2}" ]; then
+    input_dir="${2}"
+else
+    echo "Must pass an input_dir as second argument"
+fi
+
+echo "Normalizing ${input_dir} into ${output_dir}"

--- a/vaccine-feed-ingest/runners/_template/parse.sh
+++ b/vaccine-feed-ingest/runners/_template/parse.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+output_dir=""
+input_dir=""
+
+if [ -n "${1}" ]; then
+    output_dir="${1}"
+else
+    echo "Must pass an output_dir as first argument"
+fi
+
+if [ -n "${2}" ]; then
+    input_dir="${2}"
+else
+    echo "Must pass an input_dir as second argument"
+fi
+
+echo "Parsing ${input_dir} into ${output_dir}"

--- a/vaccine-feed-ingest/runners/ca/sf_gov/README.md
+++ b/vaccine-feed-ingest/runners/ca/sf_gov/README.md
@@ -1,0 +1,3 @@
+# SF GOV
+
+Example state site with only a fetch stage

--- a/vaccine-feed-ingest/runners/ca/sf_gov/fetch.sh
+++ b/vaccine-feed-ingest/runners/ca/sf_gov/fetch.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+output_dir=""
+
+if [ -n "${1}" ]; then
+    output_dir="${1}"
+else
+    echo "Must pass an output_dir as first argument"
+fi
+
+echo "Fetching into ${output_dir}"

--- a/vaccine-feed-ingest/runners/us/vaccinespotter_org/README.md
+++ b/vaccine-feed-ingest/runners/us/vaccinespotter_org/README.md
@@ -1,0 +1,3 @@
+# Vaccine Spotter
+
+Example US site with all stages

--- a/vaccine-feed-ingest/runners/us/vaccinespotter_org/fetch.sh
+++ b/vaccine-feed-ingest/runners/us/vaccinespotter_org/fetch.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+output_dir=""
+
+if [ -n "${1}" ]; then
+    output_dir="${1}"
+else
+    echo "Must pass an output_dir as first argument"
+fi
+
+echo "Fetching into ${output_dir}"

--- a/vaccine-feed-ingest/runners/us/vaccinespotter_org/normalize.sh
+++ b/vaccine-feed-ingest/runners/us/vaccinespotter_org/normalize.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+output_dir=""
+input_dir=""
+
+if [ -n "${1}" ]; then
+    output_dir="${1}"
+else
+    echo "Must pass an output_dir as first argument"
+fi
+
+if [ -n "${2}" ]; then
+    input_dir="${2}"
+else
+    echo "Must pass an input_dir as second argument"
+fi
+
+echo "Normalizing ${input_dir} into ${output_dir}"

--- a/vaccine-feed-ingest/runners/us/vaccinespotter_org/parse.sh
+++ b/vaccine-feed-ingest/runners/us/vaccinespotter_org/parse.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+output_dir=""
+input_dir=""
+
+if [ -n "${1}" ]; then
+    output_dir="${1}"
+else
+    echo "Must pass an output_dir as first argument"
+fi
+
+if [ -n "${2}" ]; then
+    input_dir="${2}"
+else
+    echo "Must pass an input_dir as second argument"
+fi
+
+echo "Parsing ${input_dir} into ${output_dir}"


### PR DESCRIPTION
## Proposals

1. Propose using `poetry` to handle requirement locks, packaging, and virtualenv. I think `poetry` has fewer pitfalls, so I like it better, but  I would be happy to use `Pipenv` if people are more accustomed to it.  I do want to use either `poetry` or `Pipenv` so we are all running in a consistent python environment.

2. Propose having a python wrapper that runs the fetch, parse, and normalize shell commands. That wrapper will handle the downloading, and uploading the files to GCS, and calling stages like `fetch.sh output_dir`

## Example commands

Note if you can also use `poetry shell` to activate the `venv` so then you can run the command directly.

- List all available sites:

    ```sh
    poetry run vaccine-feed-ingest/run.py available-sites
    ```

- Run fetch for just one site:

    ```sh
    poetry run vaccine-feed-ingest/run.py fetch ca/sf_gov
    ```

- Run fetch for all sites in CA:

    ```sh
    poetry run vaccine-feed-ingest/run.py fetch --state=ca
    ```

- Run all stages for all sites:

    ```sh
    poetry run vaccine-feed-ingest/run.py all-stages
    ```
