### PR TITLE
Finish implementation of sf_gov example

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,3 +29,8 @@ indent_size = 4
 # Makefile
 [Makefile]
 indent_style = tab
+
+# Markdown
+[*.{md,txt}]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,5 +32,6 @@ jobs:
         uses: github/super-linter@v3
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_JSCPD: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Pipeline for ingesting nationwide feed of vaccine facilities
 
 ## Usage
 
+### Quick Setup For MacOS Homebrew users
+
+```sh
+brew install python3
+brew install poetry
+poetry install
+```
+
 ### Setup Environment Once
 
 1. Install required system deps (Ubuntu/Debian):
@@ -65,20 +73,35 @@ Pipeline for ingesting nationwide feed of vaccine facilities
     poetry run vaccine-feed-ingest/run.py available-sites
     ```
 
-- Run fetch for just one site:
-
-    ```sh
-    poetry run vaccine-feed-ingest/run.py fetch ca/sf_gov
-    ```
-
 - Run fetch for all sites in CA:
 
     ```sh
-    poetry run vaccine-feed-ingest/run.py fetch --state=ca
+    poetry run vaccine-feed-ingest/run.py fetch --state=ca --output-dir=out
     ```
 
 - Run all stages for all sites:
 
     ```sh
-    poetry run vaccine-feed-ingest/run.py all-stages
+    poetry run vaccine-feed-ingest/run.py all-stages --output-dir=out
+    ```
+
+- Run fetch for just one site:
+
+    ```sh
+    # Writes ingest data to out/ca/sf_gov/ directory
+    poetry run vaccine-feed-ingest/run.py fetch ca/sf_gov --output-dir=out
+    ```
+
+- Run parse for just one site:
+
+    ```sh
+    # Parses data in out/ca/sf_gov/ directory into out/ca/sf_gov/locations.ndjson
+    poetry run vaccine-feed-ingest/run.py parse ca/sf_gov --output-dir=out
+    ```
+
+- Run normalize for just one site:
+
+    ```sh
+    # Parses data in out/ca/sf_gov/ directory into out/ca/sf_gov/locations.ndjson
+    poetry run vaccine-feed-ingest/run.py normalize ca/sf_gov --output-dir=out
     ```

--- a/vaccine-feed-ingest/normalizers/jsonschema.py
+++ b/vaccine-feed-ingest/normalizers/jsonschema.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+from typing import NamedTuple
+
+"""
+This module provides a flat Location structure so scraper authors do not need
+to understand the normalized ndjson spec:
+
+https://docs.google.com/document/d/1qxABDlRep76llrXhgwdwA6Ji3Jub-MftRvustk12XHc
+"""
+
+
+class Location(NamedTuple):
+    id: str = None
+    name: str = None
+    street1: str = None
+    street2: str = None
+    city: str = None
+    state: str = None
+    zip: str = None
+    latitude: str = None
+    longitude: str = None
+    phone: str = None
+    website: str = None
+    email: str = None
+    contact_other: str = None
+    provider_id: str = None
+    provider_brand: str = None
+    provider_brand_name: str = None
+    booking_website: str = None
+    booking_phone: str = None
+    booking_email: str = None
+    appointments_available: bool = False
+    fetched_at: str = None
+    published_at: str = None
+    fetched_from_uri: str = None
+    source: str = None
+    data: dict[str, str] = None
+
+
+def omit_empty(d):
+    def pop_empty_values(d):
+        for key, value in list(d.items()):
+            if isinstance(value, dict):
+                omit_empty(value)
+            elif value is None:
+                d.pop(key)
+            elif value == [None]:
+                d.pop(key)
+
+    pop_empty_values(d)
+    for key, value in list(d.items()):
+        if value == {}:
+            d.pop(key)
+    return d
+
+
+def to_dict(loc):
+    """ Convert Location namedtuple to nested dict """
+
+    d = {
+        "id": loc.id,
+        "name": loc.name,
+        "address": {
+            "street1": loc.street1,
+            "street2": loc.street2,
+            "city": loc.city,
+            "state": loc.state,
+            "zip": loc.zip,
+        },
+        "location": {
+            "latitude": loc.latitude,
+            "longitude": loc.longitude,
+        },
+        "contact": {
+            "phone": [loc.phone],
+            "website": [loc.website],
+            "email": [loc.email],
+            "other": [loc.contact_other],
+        },
+        "booking": {
+            "phone": loc.booking_phone,
+            "website": loc.booking_website,
+            "email": loc.booking_email,
+        },
+        "availability": {
+            "appointments": loc.appointments_available,
+        },
+        "parent_organization": {
+            "id": loc.provider_brand,
+            "name": loc.provider_brand_name,
+        },
+        "links": [
+            {
+                "authority": loc.provider_brand,
+                "id": loc.provider_id,
+            }
+        ],
+        "fetched_at": loc.fetched_at,
+        "published_at": loc.published_at,
+        "sources": [
+            {
+                "source": loc.source,
+                "id": loc.id,
+                "fetched_from_uri": loc.fetched_from_uri,
+                "fetched_at": loc.fetched_at,
+                "published_at": loc.published_at,
+                "data": loc.data,
+            }
+        ],
+    }
+
+    d = omit_empty(d)
+    return d

--- a/vaccine-feed-ingest/run.py
+++ b/vaccine-feed-ingest/run.py
@@ -28,7 +28,7 @@ logging.basicConfig(
 logger = logging.getLogger("ingest")
 
 
-def _get_site_dirs(state: Optional[str] = None) -> Iterator[pathlib.Path]:
+def _get_state_dirs(state: Optional[str] = None) -> Iterator[pathlib.Path]:
     """Return an iterator of site directory paths"""
     for state_dir in RUNNERS_DIR.iterdir():
         # Ignore private directories, in this case the _template directory
@@ -47,6 +47,15 @@ def _get_site_dir(site: str) -> Optional[pathlib.Path]:
 
     if site_dir.exists():
         return site_dir
+
+
+def _get_site_dirs(state: str, sites: str) -> Optional[pathlib.Path]:
+    if not sites:
+        site_dirs = list(_get_state_dirs(state))
+    else:
+        site_dirs = [_get_site_dir(site) for site in sites]
+
+    return site_dirs
 
 
 def _run_fetch(site_dir: pathlib.Path, output_path: pathlib.Path) -> None:
@@ -109,7 +118,7 @@ def cli():
 def available_sites(state: Optional[str]):
     """Print list of available sites, optionally filtered by state"""
 
-    for site_dir in _get_site_dirs(state):
+    for site_dir in _get_state_dirs(state):
         has_fetch = (site_dir / FETCH_CMD).exists()
         has_parse = (site_dir / PARSE_SH).exists() or (site_dir / PARSE_PY).exists()
         has_normalize = (site_dir / NORMALIZE_SH).exists() or (
@@ -136,10 +145,7 @@ def fetch(output_dir: str, state: Optional[str], sites: Optional[Sequence[str]])
         click.echo("The specified output directory does not exist!")
         return
 
-    if not sites:
-        site_dirs = list(_get_site_dirs(state))
-    else:
-        site_dirs = [_get_site_dir(site) for site in sites]
+    site_dirs = _get_site_dirs(state, sites)
 
     for site_dir in site_dirs:
         output_path = output_parent / site_dir.relative_to(RUNNERS_DIR)
@@ -160,10 +166,7 @@ def parse(output_dir: str, state: Optional[str], sites: Optional[Sequence[str]])
         click.echo("The specified output directory does not exist!")
         return
 
-    if not sites:
-        site_dirs = list(_get_site_dirs(state))
-    else:
-        site_dirs = [_get_site_dir(site) for site in sites]
+    site_dirs = _get_site_dirs(state, sites)
 
     for site_dir in site_dirs:
         output_path = output_parent / site_dir.relative_to(RUNNERS_DIR)
@@ -182,10 +185,7 @@ def normalize(output_dir: str, state: Optional[str], sites: Optional[Sequence[st
         click.echo("The specified output directory does not exist!")
         return
 
-    if not sites:
-        site_dirs = list(_get_site_dirs(state))
-    else:
-        site_dirs = [_get_site_dir(site) for site in sites]
+    site_dirs = _get_site_dirs(state, sites)
 
     for site_dir in site_dirs:
         output_path = output_parent / site_dir.relative_to(RUNNERS_DIR)
@@ -204,10 +204,7 @@ def all_stages(output_dir: str, state: Optional[str], sites: Optional[Sequence[s
         click.echo("The specified output directory does not exist!")
         return
 
-    if not sites:
-        site_dirs = list(_get_site_dirs(state))
-    else:
-        site_dirs = [_get_site_dir(site) for site in sites]
+    site_dirs = _get_site_dirs(state, sites)
 
     for site_dir in site_dirs:
         output_path = output_parent / site_dir.relative_to(RUNNERS_DIR)

--- a/vaccine-feed-ingest/runners/ca/sf_gov/README.md
+++ b/vaccine-feed-ingest/runners/ca/sf_gov/README.md
@@ -1,3 +1,3 @@
 # SF GOV
 
-Example state site with only a fetch stage
+Example state site

--- a/vaccine-feed-ingest/runners/ca/sf_gov/fetch.sh
+++ b/vaccine-feed-ingest/runners/ca/sf_gov/fetch.sh
@@ -10,4 +10,4 @@ else
     echo "Must pass an output_dir as first argument"
 fi
 
-(cd $output_dir && curl --silent "https://vaccination-site-microservice.vercel.app/api/v1/appointments" -o 'sf.json')
+(cd "$output_dir" && curl --silent "https://vaccination-site-microservice.vercel.app/api/v1/appointments" -o 'sf.json')

--- a/vaccine-feed-ingest/runners/ca/sf_gov/fetch.sh
+++ b/vaccine-feed-ingest/runners/ca/sf_gov/fetch.sh
@@ -10,4 +10,4 @@ else
     echo "Must pass an output_dir as first argument"
 fi
 
-(cd $output_dir && curl --silent 'https://vaccination-site-microservice.vercel.app/api/v1/appointments' -o 'sf.json')
+(cd $output_dir && curl --silent "https://vaccination-site-microservice.vercel.app/api/v1/appointments" -o 'sf.json')

--- a/vaccine-feed-ingest/runners/ca/sf_gov/fetch.sh
+++ b/vaccine-feed-ingest/runners/ca/sf_gov/fetch.sh
@@ -10,4 +10,4 @@ else
     echo "Must pass an output_dir as first argument"
 fi
 
-echo "Fetching into ${output_dir}"
+(cd $output_dir && curl --silent 'https://vaccination-site-microservice.vercel.app/api/v1/appointments' -o 'sf.json')

--- a/vaccine-feed-ingest/runners/ca/sf_gov/normalize.py
+++ b/vaccine-feed-ingest/runners/ca/sf_gov/normalize.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+import json
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+site_dir = pathlib.Path(__file__).parent
+state_dir = site_dir.parent
+runner_dir = state_dir.parent
+root_dir = runner_dir.parent
+
+sys.path.append(str(root_dir))
+from normalizers import jsonschema  # noqa: E402
+
+ndjson_file = sys.argv[1]
+normalized_file = sys.argv[2]
+
+with open(normalized_file, "w") as fout:
+    now = datetime.now(timezone.utc).isoformat()
+
+    with open(ndjson_file) as fin:
+        for line in fin:
+            obj = json.loads(line)
+
+            address = obj["location"]["address"]
+            address_parts = address.split(", ")
+
+            city = address_parts.pop()
+            street1 = address_parts[0]
+            street2 = None
+            if len(address_parts) > 1:
+                street2 = ", ".join(address_parts[1:])
+
+            zip = obj["location"]["zip"]
+            lat = obj["location"]["lat"]
+            long = obj["location"]["lng"]
+            uri = "https://vaccination-site-microservice.vercel.app/api/v1/appointments"
+
+            location = jsonschema.Location(
+                id=f"sf_gov:{obj['id']}",
+                name=obj["name"],
+                street1=street1,
+                street2=street2,
+                city=city,
+                zip=zip,
+                latitude=lat,
+                longitude=long,
+                booking_website=obj["booking"]["url"],
+                booking_phone=obj["booking"]["phone"],
+                appointments_available=obj["appointments"]["available"],
+                fetched_at=now,  # this is actually time parsed, not fetched
+                fetched_from_uri=uri,
+                published_at=obj["appointments"]["last_updated"],
+                source="sf_gov",
+                data=obj,
+            )
+
+            d = jsonschema.to_dict(location)
+            json.dump(d, fout)
+            fout.write("\n")

--- a/vaccine-feed-ingest/runners/ca/sf_gov/parse.py
+++ b/vaccine-feed-ingest/runners/ca/sf_gov/parse.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+import glob
+import json
+import sys
+
+site_dir = sys.argv[1]
+out_ndjson = sys.argv[2]
+
+files = glob.glob(f"{site_dir}/*.json")
+
+with open(out_ndjson, "w") as fout:
+    for file in files:
+        with open(file) as fh:
+            obj = json.load(fh)
+
+        for site in obj["data"]["sites"]:
+            json.dump(site, fout)
+            fout.write("\n")

--- a/vaccine-feed-ingest/runners/us/vaccinespotter_org/normalize.sh
+++ b/vaccine-feed-ingest/runners/us/vaccinespotter_org/normalize.sh
@@ -2,19 +2,19 @@
 
 set -Eeuo pipefail
 
-output_dir=""
-input_dir=""
+ndjson_file=""
+normalized_file=""
 
 if [ -n "${1}" ]; then
-    output_dir="${1}"
+    ndjson_file="${1}"
 else
-    echo "Must pass an output_dir as first argument"
+    echo "Must pass an ndjson_file as first argument"
 fi
 
 if [ -n "${2}" ]; then
-    input_dir="${2}"
+    normalized_file="${2}"
 else
-    echo "Must pass an input_dir as second argument"
+    echo "Must pass an normalized_file as second argument"
 fi
 
-echo "Normalizing ${input_dir} into ${output_dir}"
+echo "Normalizing ${ndjson_file} into ${normalized_file}"

--- a/vaccine-feed-ingest/runners/us/vaccinespotter_org/parse.sh
+++ b/vaccine-feed-ingest/runners/us/vaccinespotter_org/parse.sh
@@ -2,19 +2,19 @@
 
 set -Eeuo pipefail
 
-output_dir=""
-input_dir=""
+data_dir=""
+ndjson_file=""
 
 if [ -n "${1}" ]; then
-    output_dir="${1}"
+    data_dir="${1}"
 else
-    echo "Must pass an output_dir as first argument"
+    echo "Must pass an data_dir as first argument"
 fi
 
 if [ -n "${2}" ]; then
-    input_dir="${2}"
+    ndjson_file="${2}"
 else
-    echo "Must pass an input_dir as second argument"
+    echo "Must pass an nsjson_file as second argument"
 fi
 
-echo "Parsing ${input_dir} into ${output_dir}"
+echo "Parsing ${data_dir}/ into ${ndjson_file}"


### PR DESCRIPTION
Finish implementation of sf_gov example, as this is the simplest example we can provide.

The runner now takes an `--output-dir` parameter:
```
poetry run vaccine-feed-ingest/run.py all-stages --output-dir=<directory>
```

This directory should exist and be empty. The runner will create subdirectories for each site fetcher.

The cli parameters for fetch / parse / normalize have changed. The new parameters are:

```sh
fetch.sh <data_dir>
parse.sh <data_dir> <ndjson_path>
normalize.sh <ndjson_path> <normlized_ndjson_path>
```

Support parse.py and normalize.py, to keep crawler volunteers from having to jump through unnecessary hoops.