### PR TITLE
Add editor config for markdown and text files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,6 +26,11 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 
+# Markdown
+[*.{md,txt}]
+indent_style = space
+indent_size = 4
+
 # Makefile
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
Pulled out @rajbot's changes to `.editorconfig` into its own PR so we can get it merged separately