### PR TITLE
Support multiple executable languages for runner

### DIFF
--- a/vaccine-feed-ingest/run.py
+++ b/vaccine-feed-ingest/run.py
@@ -67,7 +67,7 @@ def _find_executeable(site_dir: pathlib.Path, cmd_name: str) -> Optional[pathlib
     cmd = cmds[0]
 
     if not os.access(cmd, os.X_OK):
-        logger.error("%s in %s is not marked as executable.", cmd.name)
+        logger.error("%s in %s is not marked as executable.", cmd.name, str(site_dir))
         return None
 
     return cmd

--- a/vaccine-feed-ingest/run.py
+++ b/vaccine-feed-ingest/run.py
@@ -49,7 +49,7 @@ def _get_site_dir(site: str) -> Optional[pathlib.Path]:
     if site_dir.exists():
         return site_dir
 
-      
+
 def _get_site_dirs(
     state: Optional[str], sites: Optional[Sequence[str]]
 ) -> Iterator[pathlib.Path]:
@@ -59,8 +59,8 @@ def _get_site_dirs(
     else:
         for site in sites:
             yield _get_site_dir(site)
-            
-      
+
+
 def _find_executeable(site_dir: pathlib.Path, cmd_name: str) -> Optional[pathlib.Path]:
     """Find executable. Logs an error and returs false if something is wrong."""
     cmds = list(site_dir.glob(f"{cmd_name}.*"))


### PR DESCRIPTION
This looks for files named "fetch.*", and if there is only one and it is executable, then it runs it e.g. `fetch.sh` or `fetch.py`

This will allow use to support multiple languages for the runners.