### PR TITLE
chore: return all records in ArcGIS fetch

### DIFF
--- a/vaccine_feed_ingest/ingestors/arcgis.py
+++ b/vaccine_feed_ingest/ingestors/arcgis.py
@@ -40,7 +40,7 @@ def fetch_geojson(
             if layer.properties.name not in selected_layers:
                 continue
 
-        results = layer.query()
+        results = layer.query(return_all_records=True)
         layer_id = layer.properties.id
         file_name = f"{service_item_id}_{layer_id}.json"
         print(f"Saving {layer.properties.name} layer to {file_name}")


### PR DESCRIPTION
Per [ArcGis's python documentation](https://developers.arcgis.com/python/api-reference/arcgis.features.toc.html#arcgis.features.FeatureLayer.query), setting `return_all_records = True` on a `query` causes:

> When True, the query operation will call the service until all records that satisfy the where_clause are returned.

It seems desirable to fetch all data - not just the first page - so add this parameter.