### PR TITLE
chore: shared parse.py with yml config for arcgis 

### DIFF
--- a/vaccine_feed_ingest/run.py
+++ b/vaccine_feed_ingest/run.py
@@ -292,9 +292,17 @@ def _run_parse(
     timestamp: str,
 ) -> bool:
     parse_path = _find_executeable(site_dir, PipelineStage.PARSE)
+    yml_path = None
     if not parse_path:
-        logger.info("No parse cmd for %s to run.", site_dir.name)
-        return False
+        yml_path = _find_yml(site_dir, PipelineStage.PARSE)
+
+        if not yml_path:
+            logger.info("No parse cmd or .yml config for %s to run.", site_dir.name)
+            return False
+
+        parse_path = _find_executeable(
+            RUNNERS_DIR.joinpath("_shared"), PipelineStage.PARSE
+        )
 
     fetch_run_dir = _find_latest_run_dir(
         output_dir, site_dir.parent.name, site_dir.name, PipelineStage.FETCH
@@ -328,7 +336,12 @@ def _run_parse(
         _copy_files(fetch_run_dir, parse_input_dir)
 
         subprocess.run(
-            [str(parse_path), str(parse_output_dir), str(parse_input_dir)],
+            [
+                str(parse_path),
+                str(parse_output_dir),
+                str(parse_input_dir),
+                str(yml_path),
+            ],
             check=True,
         )
 

--- a/vaccine_feed_ingest/runners/_shared/parse.py
+++ b/vaccine_feed_ingest/runners/_shared/parse.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import json
+import logging
+import os
+import pathlib
+import sys
+
+import yaml
+
+# Configure logger
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
+    datefmt="%m/%d/%Y %H:%M:%S",
+)
+logger = logging.getLogger("_shared/parse.py")
+
+OUTPUT_DIR = pathlib.Path(sys.argv[1])
+INPUT_DIR = pathlib.Path(sys.argv[2])
+YML_CONFIG = pathlib.Path(sys.argv[3])
+
+with open(YML_CONFIG, "r") as stream:
+    try:
+        config = yaml.safe_load(stream)
+    except yaml.YAMLError as exc:
+        print(exc)
+
+try:
+    state = config["state"]
+except KeyError as e:
+    logger.error(
+        "config file must have key 'state'. This config does not - %s", YML_CONFIG
+    )
+    raise e
+
+try:
+    site = config["site"]
+except KeyError as e:
+    logger.error(
+        "config file must have key 'site'. This config does not - %s", YML_CONFIG
+    )
+    raise e
+
+if site == "arcgis":
+    json_filepaths = INPUT_DIR.glob("*.json")
+
+    for in_filepath in json_filepaths:
+        with in_filepath.open() as fin:
+            arcgis_feature_json = json.load(fin)
+
+        filename, _ = os.path.splitext(in_filepath.name)
+        out_filepath = OUTPUT_DIR.joinpath(f"{filename}.parsed.ndjson")
+
+        logger.info(
+            "(%s/%s) parsing %s => %s",
+            state.upper(),
+            site.lower(),
+            in_filepath,
+            out_filepath,
+        )
+        with out_filepath.open("w") as fout:
+            for feature in arcgis_feature_json["features"]:
+                json.dump(feature, fout)
+                fout.write("\n")
+else:
+    logger.error("Site '%s' was not recognized.", site)
+    raise NotImplementedError(
+        f"Sites of type '{site}' are not parse-able via the shared parser."
+    )

--- a/vaccine_feed_ingest/runners/ak/arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/ak/arcgis/parse.yml
@@ -1,0 +1,3 @@
+---
+state: ak
+site: arcgis

--- a/vaccine_feed_ingest/runners/al/arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/al/arcgis/parse.yml
@@ -1,0 +1,3 @@
+---
+state: al
+site: arcgis

--- a/vaccine_feed_ingest/runners/az/arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/az/arcgis/parse.yml
@@ -1,0 +1,3 @@
+---
+state: az
+site: arcgis

--- a/vaccine_feed_ingest/runners/in/arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/in/arcgis/parse.yml
@@ -1,0 +1,3 @@
+---
+state: in
+site: arcgis

--- a/vaccine_feed_ingest/runners/md/arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/md/arcgis/parse.yml
@@ -1,0 +1,3 @@
+---
+state: md
+site: arcgis

--- a/vaccine_feed_ingest/runners/mo/arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/mo/arcgis/parse.yml
@@ -1,0 +1,3 @@
+---
+state: mo
+site: arcgis

--- a/vaccine_feed_ingest/runners/mt/arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/mt/arcgis/parse.yml
@@ -1,0 +1,3 @@
+---
+state: mt
+site: arcgis

--- a/vaccine_feed_ingest/runners/pa/arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/pa/arcgis/parse.yml
@@ -1,0 +1,3 @@
+---
+state: pa
+site: arcgis

--- a/vaccine_feed_ingest/runners/ri/arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/ri/arcgis/parse.yml
@@ -1,0 +1,3 @@
+---
+state: ri
+site: arcgis

--- a/vaccine_feed_ingest/runners/sc/arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/sc/arcgis/parse.yml
@@ -1,0 +1,3 @@
+---
+state: sc
+site: arcgis

--- a/vaccine_feed_ingest/runners/tx/arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/tx/arcgis/parse.yml
@@ -1,0 +1,3 @@
+---
+state: tx
+site: arcgis


### PR DESCRIPTION
Similar to #26: ArcGIS feeds have a repeatable parse pattern, and we can
make it easy to parse new feeds by re-using a single runner.

Augment vaccine-feed-ingest to accept .yml configuration files if an
executable is not provided (for the parse stage), and use that config
to run a shared ArcGIS parser. This setup is designed so that the
vaccine-feed-ingest cli commands continue to operate as expected even
when a config file is found rather than an executable runner.
While ArcGIS is the only shared parser at the moment, this setup should
be able to support more shared parsers with minimal refactoring.