### PR TITLE
chore: add normalized schema

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1000,6 +1000,21 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pydantic"
+version = "1.8.1"
+description = "Data validation and settings management using python 3.6 type hinting"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
+
+[[package]]
 name = "pyflakes"
 version = "2.3.1"
 description = "passive checker of Python programs"
@@ -1399,7 +1414,7 @@ name = "typing-extensions"
 version = "3.7.4.3"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 
 [[package]]
@@ -1484,7 +1499,7 @@ lint = ["flake8", "black", "mypy"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "ccff171cd1dfef024b60a16e980a7b9a8f707280d6f8df23740f4408063580c1"
+content-hash = "919fbaffbc33f7cced3b74132fe03dce47189dc565c2b8a5f4a1e6097a52ac44"
 
 [metadata.files]
 anyio = [
@@ -2031,6 +2046,30 @@ pycodestyle = [
 pycparser = [
     {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
+]
+pydantic = [
+    {file = "pydantic-1.8.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0c40162796fc8d0aa744875b60e4dc36834db9f2a25dbf9ba9664b1915a23850"},
+    {file = "pydantic-1.8.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:fff29fe54ec419338c522b908154a2efabeee4f483e48990f87e189661f31ce3"},
+    {file = "pydantic-1.8.1-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:fbfb608febde1afd4743c6822c19060a8dbdd3eb30f98e36061ba4973308059e"},
+    {file = "pydantic-1.8.1-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:eb8ccf12295113ce0de38f80b25f736d62f0a8d87c6b88aca645f168f9c78771"},
+    {file = "pydantic-1.8.1-cp36-cp36m-win_amd64.whl", hash = "sha256:20d42f1be7c7acc352b3d09b0cf505a9fab9deb93125061b376fbe1f06a5459f"},
+    {file = "pydantic-1.8.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:dde4ca368e82791de97c2ec019681ffb437728090c0ff0c3852708cf923e0c7d"},
+    {file = "pydantic-1.8.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3bbd023c981cbe26e6e21c8d2ce78485f85c2e77f7bab5ec15b7d2a1f491918f"},
+    {file = "pydantic-1.8.1-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:830ef1a148012b640186bf4d9789a206c56071ff38f2460a32ae67ca21880eb8"},
+    {file = "pydantic-1.8.1-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:fb77f7a7e111db1832ae3f8f44203691e15b1fa7e5a1cb9691d4e2659aee41c4"},
+    {file = "pydantic-1.8.1-cp37-cp37m-win_amd64.whl", hash = "sha256:3bcb9d7e1f9849a6bdbd027aabb3a06414abd6068cb3b21c49427956cce5038a"},
+    {file = "pydantic-1.8.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2287ebff0018eec3cc69b1d09d4b7cebf277726fa1bd96b45806283c1d808683"},
+    {file = "pydantic-1.8.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:4bbc47cf7925c86a345d03b07086696ed916c7663cb76aa409edaa54546e53e2"},
+    {file = "pydantic-1.8.1-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:6388ef4ef1435364c8cc9a8192238aed030595e873d8462447ccef2e17387125"},
+    {file = "pydantic-1.8.1-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:dd4888b300769ecec194ca8f2699415f5f7760365ddbe243d4fd6581485fa5f0"},
+    {file = "pydantic-1.8.1-cp38-cp38-win_amd64.whl", hash = "sha256:8fbb677e4e89c8ab3d450df7b1d9caed23f254072e8597c33279460eeae59b99"},
+    {file = "pydantic-1.8.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2f2736d9a996b976cfdfe52455ad27462308c9d3d0ae21a2aa8b4cd1a78f47b9"},
+    {file = "pydantic-1.8.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:3114d74329873af0a0e8004627f5389f3bb27f956b965ddd3e355fe984a1789c"},
+    {file = "pydantic-1.8.1-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:258576f2d997ee4573469633592e8b99aa13bda182fcc28e875f866016c8e07e"},
+    {file = "pydantic-1.8.1-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c17a0b35c854049e67c68b48d55e026c84f35593c66d69b278b8b49e2484346f"},
+    {file = "pydantic-1.8.1-cp39-cp39-win_amd64.whl", hash = "sha256:e8bc082afef97c5fd3903d05c6f7bb3a6af9fc18631b4cc9fedeb4720efb0c58"},
+    {file = "pydantic-1.8.1-py3-none-any.whl", hash = "sha256:e3f8790c47ac42549dc8b045a67b0ca371c7f66e73040d0197ce6172b385e520"},
+    {file = "pydantic-1.8.1.tar.gz", hash = "sha256:26cf3cb2e68ec6c0cfcb6293e69fb3450c5fd1ace87f46b64f678b0d29eac4c3"},
 ]
 pyflakes = [
     {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ pathy = "^0.4.0"
 isort = "^5.8.0"
 arcgis = "^1.8.5"
 PyYAML = "^5.4.1"
+pydantic = "^1.8.1"
 
 [tool.poetry.dev-dependencies]
 

--- a/vaccine_feed_ingest/run.py
+++ b/vaccine_feed_ingest/run.py
@@ -487,7 +487,7 @@ def normalize(
     """Run normalize process for specified sites."""
     timestamp = _generate_run_timestamp()
     site_dirs = list(_get_site_dirs(state, sites))
-    print(site_dirs)
+
     for site_dir in site_dirs:
         _run_normalize(site_dir, output_dir, timestamp)
 

--- a/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python
+
+import datetime
+import json
+import logging
+import os
+import pathlib
+import re
+import sys
+from typing import List, Optional
+
+# import schema
+site_dir = pathlib.Path(__file__).parent
+state_dir = site_dir.parent
+runner_dir = state_dir.parent
+root_dir = runner_dir.parent
+sys.path.append(str(root_dir))
+
+from schema import schema  # noqa: E402
+
+# Configure logger
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
+    datefmt="%m/%d/%Y %H:%M:%S",
+)
+logger = logging.getLogger("ak/arcgis/normalize.py")
+
+
+def _get_availability(site: dict) -> schema.Availability:
+    manufacturer_field = site["attributes"]["flu_walkins"]
+
+    potentials = {
+        "no_please_make_an_appointment": schema.Availability(appointments=True),
+        "yes": schema.Availability(drop_in=True),
+    }
+
+    try:
+        return potentials[manufacturer_field]
+    except KeyError as e:
+        logger.error("Unexpected availability code: %s", e)
+
+    return None
+
+
+def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
+    avail_field = site["attributes"]["flu_vaccinations"]
+    vaccines_field = avail_field.lower().split(",")
+
+    potentials = {
+        "pfizer": schema.Vaccine(vaccine="pfizer"),
+        "moderna": schema.Vaccine(vaccine="moderna"),
+        "janssen": schema.Vaccine(vaccine="janssen"),
+        "jjj": schema.Vaccine(vaccine="janssen"),
+    }
+
+    inventory = []
+
+    for vf in vaccines_field:
+        try:
+            inventory.append(potentials[vf])
+        except KeyError as e:
+            logger.error("Unexpected vaccine type: %s", e)
+
+    if len(inventory) > 0:
+        return inventory
+
+    return None
+
+
+def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:
+    contacts = []
+    if site["attributes"]["phone"]:
+        sourcePhone = re.sub("[^0-9]", "", site["attributes"]["phone"])
+        if len(sourcePhone) == 11:
+            sourcePhone = sourcePhone[1:]
+        phone = f"({sourcePhone[0:3]}) {sourcePhone[3:6]}-{sourcePhone[6:]}"
+        contacts.append(schema.Contact(phone=phone))
+
+    if site["attributes"]["publicEmail"]:
+        contacts.append(schema.Contact(email=site["attributes"]["publicEmail"]))
+
+    if site["attributes"]["publicWebsite"]:
+        contacts.append(schema.Contact(website=site["attributes"]["publicWebsite"]))
+
+    if len(contacts) > 0:
+        return contacts
+
+    return None
+
+
+def _get_notes(site: dict) -> Optional[List[str]]:
+    if site["attributes"]["publicNotes"]:
+        return [site["attributes"]["publicNotes"]]
+
+    return None
+
+
+def _get_published_at(site: dict) -> Optional[str]:
+    date_with_millis = site["attributes"]["datesubmited"]
+    if date_with_millis:
+        date = datetime.datetime.fromtimestamp(date_with_millis / 1000)  # Drop millis
+        return date.isoformat()
+
+    return None
+
+
+def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLocation:
+    return schema.NormalizedLocation(
+        id=f"ak_arcgis_{site['attributes']['globalid']}",
+        name=site["attributes"]["vaccinationSite"],
+        address=schema.Address(
+            street1=site["attributes"]["address"],
+            street2=None,
+            city=site["attributes"]["city"],
+            state="AK",
+            zip=site["attributes"]["zipcode"],
+        ),
+        location=schema.LatLng(
+            latitude=site["geometry"]["y"],
+            longitude=site["geometry"]["x"],
+        ),
+        contact=_get_contacts(site),
+        languages=None,
+        opening_dates=None,
+        opening_hours=None,
+        availability=_get_availability(site),
+        inventory=_get_inventory(site),
+        access=None,
+        parent_organization=None,
+        links=None,
+        notes=_get_notes(site),
+        active=None,
+        source=schema.Source(
+            source="arcgis",
+            id=site["attributes"]["globalid"],
+            fetched_from_uri="https://services1.arcgis.com/WzFsmainVTuD5KML/ArcGIS/rest/services/COVID19_Vaccine_Site_Survey_API/FeatureServer/0",  # noqa: E501
+            fetched_at=timestamp,
+            published_at=_get_published_at(site),
+            data=json.dumps(site),
+        ),
+    )
+
+
+output_dir = pathlib.Path(sys.argv[1])
+input_dir = pathlib.Path(sys.argv[2])
+
+json_filepaths = input_dir.glob("*.ndjson")
+
+parsed_at_timestamp = datetime.datetime.utcnow().isoformat()
+
+for in_filepath in json_filepaths:
+    filename, _ = os.path.splitext(in_filepath.name)
+    out_filepath = output_dir / f"{filename}.normalized.ndjson"
+
+    logger.info(
+        "normalizing %s => %s",
+        in_filepath,
+        out_filepath,
+    )
+
+    with in_filepath.open() as fin:
+        with out_filepath.open("w") as fout:
+            for site_json in fin:
+                parsed_site = json.loads(site_json)
+
+                normalized_site = _get_normalized_location(
+                    parsed_site, parsed_at_timestamp
+                )
+
+                json.dump(normalized_site.dict(), fout)
+                fout.write("\n")

--- a/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
@@ -28,7 +28,7 @@ logger = logging.getLogger("ak/arcgis/normalize.py")
 
 
 def _get_availability(site: dict) -> schema.Availability:
-    manufacturer_field = site["attributes"]["flu_walkins"]
+    avail_field = site["attributes"]["flu_walkins"]
 
     potentials = {
         "no_please_make_an_appointment": schema.Availability(appointments=True),
@@ -36,7 +36,7 @@ def _get_availability(site: dict) -> schema.Availability:
     }
 
     try:
-        return potentials[manufacturer_field]
+        return potentials[avail_field]
     except KeyError as e:
         logger.error("Unexpected availability code: %s", e)
 
@@ -44,8 +44,7 @@ def _get_availability(site: dict) -> schema.Availability:
 
 
 def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
-    avail_field = site["attributes"]["flu_vaccinations"]
-    vaccines_field = avail_field.lower().split(",")
+    vaccines_field = site["attributes"]["flu_vaccinations"].lower().split(",")
 
     potentials = {
         "pfizer": schema.Vaccine(vaccine="pfizer"),

--- a/vaccine_feed_ingest/schema/schema.py
+++ b/vaccine_feed_ingest/schema/schema.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class Address(BaseModel):
+    """
+    {
+        "street1": str,
+        "street2": str,
+        "city": str,
+        "state": str as state initial e.g. CA,
+        "zip": str,
+    },
+    """
+
+    street1: str
+    street2: Optional[str]
+    city: str
+    state: str
+    zip: str
+
+
+class LatLng(BaseModel):
+    """
+    {
+        "latitude": float,
+        "longitude": float,
+    },
+    """
+
+    latitude: float
+    longitude: float
+
+
+class Contact(BaseModel):
+    """
+    {
+        "contact_type": str as contact type enum e.g. booking,
+        "phone": str as (###) ###-###,
+        "website": str,
+        "email": str,
+        "other": str,
+    }
+    """
+
+    contact_type: Optional[str]
+    phone: Optional[str]
+    website: Optional[str]
+    email: Optional[str]
+    other: Optional[str]
+
+
+class OpenDate(BaseModel):
+    """
+    {
+        "opens": str as iso8601 date,
+        "closes": str as iso8601 date,
+    }
+    """
+
+    opens: Optional[str]
+    closes: Optional[str]
+
+
+class OpenHour(BaseModel):
+    """
+    {
+        "day": str as day of week enum e.g. monday,
+        "opens": str as hh:mm:ss,
+        "closes": str as hh:mm:ss,
+    }
+    """
+
+    day: str
+    open: str
+    closes: str
+
+
+class Availability(BaseModel):
+    """
+    {
+        "drop_in": bool,
+        "appointments": bool,
+    },
+    """
+
+    drop_in: Optional[bool]
+    appointments: Optional[bool]
+
+
+class Vaccine(BaseModel):
+    """
+    {
+        "vaccine": str as vaccine type enum,
+        "supply_level": str as supply level enum e.g. more_than_48hrs
+    }
+    """
+
+    vaccine: str
+    supply_level: Optional[str]
+
+
+class Access(BaseModel):
+    """
+    {
+        "walk": bool,
+        "drive": bool,
+        "wheelchair": bool,
+    }
+    """
+
+    walk: Optional[str]
+    drive: Optional[str]
+    wheelchair: Optional[str]
+
+
+class Organization(BaseModel):
+    """
+    {
+        "id": str as parent organization enum e.g. rite_aid,
+        "name": str,
+    }
+    """
+
+    id: str
+    name: str
+
+
+class Link(BaseModel):
+    """
+    {
+        "authority": str as authority enum e.g. rite_aid or google_places,
+        "id": str as id used by authority to reference this location e.g. 4096,
+        "uri": str as uri used by authority to reference this location,
+    }
+    """
+
+    authority: str
+    id: str
+    uri: str
+
+
+class Source(BaseModel):
+    """
+    {
+        "source": str as source type enum e.g. vaccinespotter,
+        "id": str as source defined id e.g. 7382088,
+        "fetched_from_uri": str as uri where data was fetched from,
+        "fetched_at": str as iso8601 datetime (when scraper ran),
+        "published_at": str as iso8601 datetime (when source claims it updated),
+        "data": {...parsed source data in source schema...},
+    }
+    """
+
+    source: str
+    id: str
+    fetched_from_uri: str
+    fetched_at: str
+    published_at: Optional[str]
+    data: str
+
+
+class NormalizedLocation(BaseModel):
+    id: str
+    name: str
+    address: Address
+    location: LatLng
+    contact: Optional[List[Contact]]
+    languages: Optional[List[str]]  # [str as ISO 639-1 code]
+    opening_dates: Optional[List[OpenDate]]
+    opening_hours: Optional[List[OpenHour]]
+    availability: Optional[Availability]
+    inventory: Optional[List[Vaccine]]
+    access: Optional[Access]
+    parent_organization: Optional[Organization]
+    links: Optional[List[Link]]
+    notes: Optional[List[str]]
+    active: Optional[bool]
+    source: Source


### PR DESCRIPTION
- chore: add normalized schema data types

Codify discussed target schema into classes with type hints, using
pydantic for runtime validation and serialization.

Future work can improve these types (e.g., enforcing ISO format for the
date and time fields rather than accepting arbitrary strings), but this
should be a sufficient starting point.

- chore: normalize ak/arcgis using data types

A sample normalization stage using the above types.
