### PR TITLE
chore: drop seconds from open hours schema

### DIFF
--- a/vaccine_feed_ingest/schema/schema.py
+++ b/vaccine_feed_ingest/schema/schema.py
@@ -69,8 +69,8 @@ class OpenHour(BaseModel):
     """
     {
         "day": str as day of week enum e.g. monday,
-        "opens": str as hh:mm:ss,
-        "closes": str as hh:mm:ss,
+        "opens": str as hh:mm,
+        "closes": str as hh:mm,
     }
     """
 


### PR DESCRIPTION
Per discussion offline, dropping `:ss` from schema for open hours.