### PR TITLE
parse nyc_arcgis

### DIFF
--- a/vaccine_feed_ingest/runners/ny/nyc_arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/ny/nyc_arcgis/parse.yml
@@ -1,0 +1,4 @@
+---
+state: ny
+site: nyc_arcgis
+parser: arcgis_features


### PR DESCRIPTION
Fixes #54 

Parse data from NYC's ArcGIS FeatureServer.

Presently the data contains ~600 rows, here are two samples:

```ndjson
{"attributes": {"ADA_Compliant": "Yes", "AdditionalInfo": "The physically accessible pathway to the entrance is on Irving Ave", "Address": "400 Irving Avenue", "Address2": "", "AgesServed": "", "AgesServed2": "", "AgesServed3": "", "AgesServed_Over18": "", "AgesServed_Under18": "", "AppointmentAvailability": "Available", "AvailabilityCount": null, "AvailabilityETLLastModified": 1619157370031, "AvailabilitySource": "NYC DoITT Salesforce", "AvailabilitySourceLastModified": null, "Borough": "Brooklyn", "ClosingHour_Friday": 2030, "ClosingHour_Monday": -1, "ClosingHour_Saturday": 1800, "ClosingHour_Sunday": 1900, "ClosingHour_Thursday": 2030, "ClosingHour_Tuesday": -1, "ClosingHour_Wednesday": -1, "EndDate": null, "FacilityFlag": null, "FacilityName": "NYC Vaccine Hub - Bushwick Educational Campus", "FacilityType": "Community Health Center/Clinic", "HoursStart_Friday": 1400, "HoursStart_Monday": -1, "HoursStart_Saturday": 900, "HoursStart_Sunday": 1000, "HoursStart_Thursday": 1400, "HoursStart_Tuesday": -1, "HoursStart_Wednesday": -1, "Hours_Friday": "2:00 PM - 8:30 PM", "Hours_Monday": "Closed - Closed", "Hours_Saturday": "9:00 AM - 6:00 PM", "Hours_Sunday": "10:00 AM - 7:00 PM", "Hours_Thursday": "2:00 PM - 8:30 PM", "Hours_Tuesday": "Closed - Closed", "Hours_Wednesday": "Closed - Closed", "Intake_ApptPreferred": "No", "Intake_ApptRequired": "Yes", "Intake_WalkIn": "No", "LastModifiedDate": 1618946042000, "Latitude": 40.6967365, "LocationID": "a0e3A000008ISW8QAO", "Longitude": -73.9120081, "OBJECTID": 8, "Payment_Cash": "No", "Payment_Free": "Yes", "Payment_Medicaid": "No", "Payment_Medicare": "No", "Payment_Private": "No", "Payment_Sliding": "No", "Payment_Uninsured": "No", "Phone": "(877) 829-4692", "Priority_EssentialWorkers": "Yes", "ServiceCategory": "Vaccines", "ServiceID": "a104V0000064pFnQAI", "ServiceType": "COVID Vaccine Moderna", "ServiceType_JohnsonAndJohnson": "No", "ServiceType_Moderna": "Yes", "ServiceType_Pfizer": "No", "StartDate": null, "Vaccine_Restrictions": "Walk-up vaccinations available to those 50 years or older", "Website": "https://www.nyc.gov/vax4nyc", "WebsiteLabel": null, "Zipcode": 11237}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -73.9120081, "y": 40.6967365}}
{"attributes": {"ADA_Compliant": "No", "AdditionalInfo": "", "Address": "459 East 149th Street", "Address2": "", "AgesServed": "", "AgesServed2": "", "AgesServed3": "", "AgesServed_Over18": "", "AgesServed_Under18": "", "AppointmentAvailability": null, "AvailabilityCount": null, "AvailabilityETLLastModified": null, "AvailabilitySource": null, "AvailabilitySourceLastModified": null, "Borough": "Bronx", "ClosingHour_Friday": -1, "ClosingHour_Monday": -1, "ClosingHour_Saturday": -1, "ClosingHour_Sunday": -1, "ClosingHour_Thursday": -1, "ClosingHour_Tuesday": -1, "ClosingHour_Wednesday": -1, "EndDate": null, "FacilityFlag": null, "FacilityName": "Sun River Health The Hub", "FacilityType": "Community Health Center/Clinic", "HoursStart_Friday": -1, "HoursStart_Monday": -1, "HoursStart_Saturday": -1, "HoursStart_Sunday": -1, "HoursStart_Thursday": -1, "HoursStart_Tuesday": -1, "HoursStart_Wednesday": -1, "Hours_Friday": "null - null", "Hours_Monday": "null - null", "Hours_Saturday": "null - null", "Hours_Sunday": "null - null", "Hours_Thursday": "null - null", "Hours_Tuesday": "null - null", "Hours_Wednesday": "null - null", "Intake_ApptPreferred": "No", "Intake_ApptRequired": "Yes", "Intake_WalkIn": "No", "LastModifiedDate": 1616782705000, "Latitude": 40.8154183, "LocationID": "a0e4V000008NNeIQAW", "Longitude": -73.9151832, "OBJECTID": 9, "Payment_Cash": "No", "Payment_Free": "Yes", "Payment_Medicaid": "No", "Payment_Medicare": "No", "Payment_Private": "No", "Payment_Sliding": "No", "Payment_Uninsured": "No", "Phone": "(929) 459-2255", "Priority_EssentialWorkers": null, "ServiceCategory": "Vaccines", "ServiceID": "a104V0000064pTgQAI", "ServiceType": "COVID Vaccine Moderna", "ServiceType_JohnsonAndJohnson": "No", "ServiceType_Moderna": "Yes", "ServiceType_Pfizer": "No", "StartDate": null, "Vaccine_Restrictions": "", "Website": "https://apps.health.ny.gov/doh2/applinks/cdmspr/2/counties?OpID=50501244", "WebsiteLabel": null, "Zipcode": 10455}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -73.9151832, "y": 40.8154183}}
```