### PR TITLE
add fetch.yml for GISCorps national locations for vaccination sites

### DIFF
--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/fetch.yml
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/fetch.yml
@@ -1,0 +1,7 @@
+---
+state: us
+arcgis:
+# https://covid-19-giscorps.hub.arcgis.com/app/3b4bd11928ec488281b0280d4d45533a
+- id: c50a1a352e944a66aed98e61952051ef
+  layer_names:
+  - Testing Locations # this seems strange that the layer is called testing locations but the data seems accurate


### PR DESCRIPTION
GIScorps is a group of volunteers familiar with GIS systems that have been compiling a national dataset of testing (and later vaccination) locations for a few months already. Might be worth reaching out to them. Let me know and I can do an introduction with the person I've been in email contact with.

This data is likely to overlap quite a lot with existing data you may have and I'm sure they would also like to incorporate any new or modified data back into their own dataset for the various organizations that use that data. There are some details and links to their bulk-import spreadsheet and schemas at https://github.com/VacFind/GeoCompare/issues/7 and also in https://github.com/VacFind/GeoCompare/wiki/GISCorps-Output-Format