### PR TITLE
add WA fetch script

### DIFF
--- a/vaccine_feed_ingest/runners/wa/prepmod/fetch.py
+++ b/vaccine_feed_ingest/runners/wa/prepmod/fetch.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+import requests
+
+base_url = "https://prepmod.doh.wa.gov/clinic/search"
+
+output_dir = sys.argv[1]
+if output_dir is None:
+    print("Must pass an output_dir as first argument")
+
+page = 1
+while True:
+    url = "{}?page={}".format(base_url, page)
+    response = requests.get(url, allow_redirects=False)
+
+    # when out of results, will return 302
+    if response.status_code != 200:
+        break
+
+    with open(os.path.join(output_dir, "{}.html".format(page)), "w") as f:
+        f.write(response.text)
+
+    page += 1


### PR DESCRIPTION
Scrape the WA prepmod site html, continuing until there are no more pages and the request returns 302

I do not think an API exists, either officially or from poking around with adding `.json` to things so this is what we have to work with.

fixes #122 