### PR TITLE
prevent warning about executability from being generated for yml files

### DIFF
--- a/vaccine_feed_ingest/stages/site.py
+++ b/vaccine_feed_ingest/stages/site.py
@@ -83,6 +83,10 @@ def find_executeable(
     if not cmd:
         return None
 
+    # yml files do not need to be executable
+    if cmd.name.endswith(".yml"):
+        return None
+
     if not os.access(cmd, os.X_OK):
         logger.warn("%s in %s is not marked as executable.", cmd.name, str(site_dir))
         return None


### PR DESCRIPTION
When running any stages of the pipeline that are defined by `.yml` files, a warning about executability is presented:

```
04/24/2021 10:23:18 WARNING:ingest:parse.yml in /path/to/vaccine-feed-ingest/vaccine_feed_ingest/runners/wi/arcgis_map is not marked as executable.
```

it seems to me that yml files should not be executable (in fact things broke when I set my yml file to be executable). So this warning may cause needless confusion for people when a yml file passes through this function. In this PR I have added a check that tests for the presence of a yml file and passes it though as if it were not executable, but without generating a warning.

This check could also be moved inside the executable test to just silence the warning if that style is preferred.