### PR TITLE
Add IL juvare fetcher

### DIFF
--- a/vaccine_feed_ingest/runners/il/juvare/README.md
+++ b/vaccine_feed_ingest/runners/il/juvare/README.md
@@ -1,3 +1,5 @@
+# IL juvare
+
 Scrapes the Illinois Department of Public Health vaccine appointment form at
 <https://covidvaccination.dph.illinois.gov/>. This form lists sites with
 available appointments, using [Juvare](https://www.juvare.com).

--- a/vaccine_feed_ingest/runners/il/juvare/README.md
+++ b/vaccine_feed_ingest/runners/il/juvare/README.md
@@ -1,0 +1,6 @@
+Scrapes the Illinois Department of Public Health vaccine appointment form at
+<https://covidvaccination.dph.illinois.gov/>. This form lists sites with
+available appointments, using [Juvare](https://www.juvare.com).
+
+NOTE: it may be possible to scrape additional information, like phone numbers,
+by following the link for each site. Example: <https://archive.md/CRuvx>.

--- a/vaccine_feed_ingest/runners/il/juvare/fetch.sh
+++ b/vaccine_feed_ingest/runners/il/juvare/fetch.sh
@@ -15,7 +15,7 @@ cd "${output_dir}"
 
 # Build ID changes frequently.
 curl --silent -o index.html "https://covidvaccination.dph.illinois.gov/"
-BUILD_ID=$(sed -ne 's/.*"buildId":"\([^"]\+\)".*/\1/p' index.html)
+BUILD_ID=$(sed -Ene 's/.*"buildId":"([^"]+)".*/\1/p' index.html)
 echo "Build ID is ${BUILD_ID}"
 
 curl --silent -o events.json "https://covidvaccination.dph.illinois.gov/_next/data/${BUILD_ID}/events.json"

--- a/vaccine_feed_ingest/runners/il/juvare/fetch.sh
+++ b/vaccine_feed_ingest/runners/il/juvare/fetch.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+output_dir=""
+
+if [ -n "${1}" ]; then
+    output_dir="${1}"
+else
+    echo "Must pass an output_dir as first argument"
+fi
+
+echo "Fetching into ${output_dir}"
+cd "${output_dir}"
+
+# Build ID changes frequently.
+curl --silent -o index.html "https://covidvaccination.dph.illinois.gov/"
+BUILD_ID=$(sed -ne 's/.*"buildId":"\([^"]\+\)".*/\1/p' index.html)
+echo "Build ID is ${BUILD_ID}"
+
+curl --silent -o events.json "https://covidvaccination.dph.illinois.gov/_next/data/${BUILD_ID}/events.json"


### PR DESCRIPTION
Scrapes the Illinois Department of Public Health vaccine appointment form at <https://covidvaccination.dph.illinois.gov/>. This form lists sites with available appointments, using [Juvare](https://www.juvare.com).

NOTE: it may be possible to scrape additional information, like phone numbers, by following the link for each site. Example: <https://archive.md/CRuvx>.

Fixes #150.