### PR TITLE
remove TN and MT arcgis data sources

### DIFF
--- a/vaccine_feed_ingest/runners/mt/arcgis/fetch.yml
+++ b/vaccine_feed_ingest/runners/mt/arcgis/fetch.yml
@@ -1,6 +1,0 @@
----
-state: mt
-arcgis:
-- id: cba5b18cfc82436fbd645327c2699ddf
-  layer_names:
-  - COVID_Vaccinations_PRD

--- a/vaccine_feed_ingest/runners/mt/arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/mt/arcgis/parse.yml
@@ -1,4 +1,0 @@
----
-state: mt
-site: arcgis
-parser: arcgis_features

--- a/vaccine_feed_ingest/runners/tn/arcgis/fetch.yml
+++ b/vaccine_feed_ingest/runners/tn/arcgis/fetch.yml
@@ -7,6 +7,3 @@ arcgis:
 - id: 3889a93fc4954314bd856da48200874b
   layer_names:
   - TN_COVID_19_Assessment_Sites
-- id: f491eed4a4d546c88610ac44ed65d698
-  layer_names:
-  - TN_Covid_Counties

--- a/vaccine_feed_ingest/runners/tn/arcgis/fetch.yml
+++ b/vaccine_feed_ingest/runners/tn/arcgis/fetch.yml
@@ -1,9 +1,0 @@
----
-state: tn
-arcgis:
-- id: 0000e236dfae4ba188a4fd85bc65d628
-  layer_names:
-  - TN_COVID_19_Assessment_Sites
-- id: 3889a93fc4954314bd856da48200874b
-  layer_names:
-  - TN_COVID_19_Assessment_Sites

--- a/vaccine_feed_ingest/runners/tn/arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/tn/arcgis/parse.yml
@@ -1,4 +1,0 @@
----
-state: tn
-site: arcgis
-parser: arcgis_features


### PR DESCRIPTION
per the linked issue, it seems like these two states do not offer vaccination site locations in their GIS data.

Per my comments in the individual issues for these states, this data may exist in the GISCorps dataset and can be submitted using the forms and spreadsheet templates available from the  GISCorps site (should be findable from here: https://covid-19-giscorps.hub.arcgis.com/)


fixes #158 