### PR TITLE
Add normalizer for nv/immunizenevada_org.

### DIFF
--- a/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
+++ b/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
@@ -11,6 +11,14 @@ from vaccine_feed_ingest.schema import schema
 from vaccine_feed_ingest.utils.normalize import provider_id_from_name
 
 
+def format_phone(phone: str) -> str:
+    ph = re.sub(r"[^0-9]", "", phone)
+    if len(ph) == 11:
+        ph = ph[1:]
+    formatted = "({}) {}-{}".format(ph[0:3], ph[3:6], ph[6:10])
+    return formatted
+
+
 def _get_id(site: dict) -> str:
     return f"immunizenevada_org:{site['id']}"
 
@@ -48,7 +56,7 @@ def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:
     if "contact-phone" in site:
         phone_contact = schema.Contact(
             contact_type="general",
-            phone=site["contact-phone"],
+            phone=format_phone(site["contact-phone"]),
         )
         contacts = [phone_contact]
 

--- a/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
+++ b/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
@@ -3,6 +3,7 @@
 import datetime
 import json
 import pathlib
+import re
 import sys
 from typing import List, Optional
 
@@ -12,6 +13,17 @@ from vaccine_feed_ingest.utils.normalize import provider_id_from_name
 
 def _get_id(site: dict) -> str:
     return f"immunizenevada_org:{site['id']}"
+
+
+def _get_title(title: str) -> str:
+    """Return normalized title.
+
+    Age restrictions in the form of "(16+)" will be removed. Otherwise,
+    the title will be returned unaltered.
+
+    """
+    title = re.sub(r"\([0-9]+\+\)", "", title)
+    return title
 
 
 def _get_address(address: str) -> schema.Address:
@@ -75,7 +87,7 @@ def _get_links(site: dict) -> Optional[List[schema.Link]]:
 def normalize(site: dict, timestamp: str) -> schema.NormalizedLocation:
     return schema.NormalizedLocation(
         id=_get_id(site),
-        name=site["title"],
+        name=_get_title(site["title"]),
         address=_get_address(site["address"]),
         location=schema.LatLng(
             latitude=site["lat"],

--- a/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
+++ b/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
@@ -94,7 +94,7 @@ def normalize(site: dict, timestamp: str) -> schema.NormalizedLocation:
         active=None,
         source=schema.Source(
             source="immunizenevada_org",
-            id=site["title"],
+            id=site["id"],
             fetched_at=timestamp,
             fetched_from_uri="https://www.immunizenevada.org/covid-19-vaccine-locator",
             data=site,

--- a/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
+++ b/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
@@ -11,7 +11,7 @@ from vaccine_feed_ingest.utils.normalize import provider_id_from_name
 
 
 def _get_id(site: dict) -> str:
-    return f"immunizenevada_org:{site['title']}"
+    return f"immunizenevada_org:{site['id']}"
 
 
 def _get_address(address: str) -> schema.Address:

--- a/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
+++ b/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
@@ -74,12 +74,7 @@ def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:
 
 
 def _get_links(site: dict) -> Optional[List[schema.Link]]:
-    links = []
-    immunize_nv_link = schema.Link(
-        authority="immunizenevada_org",
-        id=site["title"],
-    )
-    links.append(immunize_nv_link)
+    links = None
 
     parsed_provider_link = provider_id_from_name(site["title"])
     if parsed_provider_link is not None:
@@ -87,7 +82,7 @@ def _get_links(site: dict) -> Optional[List[schema.Link]]:
             authority=parsed_provider_link[0],
             id=parsed_provider_link[1],
         )
-        links.append(provider_link)
+        links = [provider_link]
 
     return links
 

--- a/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
+++ b/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
@@ -45,22 +45,22 @@ def _get_address(address: str) -> schema.Address:
 def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:
     contacts = None
 
-    phone = None
     if "contact-phone" in site:
-        phone = site["contact-phone"]
+        phone_contact = schema.Contact(
+            contact_type="general",
+            phone=site["contact-phone"],
+        )
+        contacts = [phone_contact]
 
     # Filter out sites with a url of "/"
-    website = None
     if site["url"].startswith("http"):
-        website = site["url"]
-
-    if phone or website:
-        general_contact = schema.Contact(
+        web_contact = schema.Contact(
             contact_type="general",
-            phone=phone,
-            website=website,
+            website=site["url"],
         )
-        contacts = [general_contact]
+        if contacts is None:
+            contacts = []
+        contacts.append(web_contact)
 
     return contacts
 

--- a/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
+++ b/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+
+import datetime
+import json
+import pathlib
+import sys
+from typing import List, Optional
+
+from vaccine_feed_ingest.schema import schema
+from vaccine_feed_ingest.utils.normalize import provider_id_from_name
+
+
+def _get_id(site: dict) -> str:
+    return f"immunizenevada_org:{site['title']}"
+
+
+def _get_address(address: str) -> schema.Address:
+    parts = address.split(",")
+    street2 = None
+    if len(parts) == 5:
+        street2 = parts[1]
+
+    result = schema.Address(
+        street1=parts[0],
+        street2=street2,
+        city=parts[-3],
+        state=parts[-2],
+        zip=parts[-1],
+    )
+    return result
+
+
+def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:
+    contacts = None
+
+    phone = None
+    if "contact-phone" in site:
+        phone = site["contact-phone"]
+
+    # Filter out sites with a url of "/"
+    website = None
+    if site["url"].startswith("http"):
+        website = site["url"]
+
+    if phone or website:
+        general_contact = schema.Contact(
+            contact_type="general",
+            phone=phone,
+            website=website,
+        )
+        contacts = [general_contact]
+
+    return contacts
+
+
+def _get_links(site: dict) -> Optional[List[schema.Link]]:
+    links = []
+    immunize_nv_link = schema.Link(
+        authority="immunizenevada_org",
+        id=site["title"],
+    )
+    links.append(immunize_nv_link)
+
+    parsed_provider_link = provider_id_from_name(site["title"])
+    if parsed_provider_link is not None:
+        provider_link = schema.Link(
+            authority=parsed_provider_link[0],
+            id=parsed_provider_link[1],
+        )
+        links.append(provider_link)
+
+    return links
+
+
+def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLocation:
+    return schema.NormalizedLocation(
+        id=_get_id(site),
+        name=site["title"],
+        address=_get_address(site["address"]),
+        location=schema.LatLng(
+            latitude=site["lat"],
+            longitude=site["lng"],
+        ),
+        contact=_get_contacts(site),
+        languages=None,
+        opening_dates=None,
+        opening_hours=None,
+        availability=None,
+        inventory=None,
+        access=None,
+        parent_organization=None,
+        links=_get_links(site),
+        notes=None,
+        active=None,
+        source=schema.Source(
+            source="immunizenevada_org",
+            id=site["title"],
+            fetched_at=timestamp,
+            fetched_from_uri="https://www.immunizenevada.org/covid-19-vaccine-locator",
+            data=site,
+        ),
+    )
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    output_dir = pathlib.Path(argv[0])
+    input_dir = pathlib.Path(argv[1])
+    ndjson_filepaths = input_dir.glob("*.ndjson")
+    parsed_at_timestamp = datetime.datetime.utcnow().isoformat()
+
+    for input_file in ndjson_filepaths:
+        slug = input_file.name.split(".", maxsplit=1)[0]
+        output_file = output_dir / f"{slug}.normalized.ndjson"
+
+        with input_file.open() as in_fh:
+            with output_file.open("w") as out_fh:
+                for site_json in in_fh:
+                    parsed_site = json.loads(site_json)
+                    normalized_site = _get_normalized_location(
+                        parsed_site,
+                        parsed_at_timestamp,
+                    )
+                    line = normalized_site.json()
+                    out_fh.write(line)
+                    out_fh.write("\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
+++ b/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
@@ -72,7 +72,7 @@ def _get_links(site: dict) -> Optional[List[schema.Link]]:
     return links
 
 
-def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLocation:
+def normalize(site: dict, timestamp: str) -> schema.NormalizedLocation:
     return schema.NormalizedLocation(
         id=_get_id(site),
         name=site["title"],
@@ -118,11 +118,8 @@ def main(argv=None):
         with input_file.open() as in_fh:
             with output_file.open("w") as out_fh:
                 for site_json in in_fh:
-                    parsed_site = json.loads(site_json)
-                    normalized_site = _get_normalized_location(
-                        parsed_site,
-                        parsed_at_timestamp,
-                    )
+                    site = json.loads(site_json)
+                    normalized_site = normalize(site, parsed_at_timestamp)
                     line = normalized_site.json()
                     out_fh.write(line)
                     out_fh.write("\n")

--- a/vaccine_feed_ingest/runners/nv/immunizenevada_org/parse.py
+++ b/vaccine_feed_ingest/runners/nv/immunizenevada_org/parse.py
@@ -87,8 +87,12 @@ def generate_id(name):
     to produce a single, consistent ID.
 
     """
-    # Strip off parenthetical age info in the name, like "(16+)".
-    id = re.sub(r"\([0-9+]+\)", "", name)
+    # Strip off parenthetical age info found in some NV location names.
+    #
+    # This regex only works if the age restriction follows the exact format
+    # where the numeric age is followed by a "+" and is contained in
+    # parentheses.
+    id = re.sub(r"\([0-9]+\+\)", "", name)
 
     # Strip whitespace from ends.
     id = id.strip()


### PR DESCRIPTION
Fixes #93 

Two questions:

1. There wasn't a natural ID in the fetched data, so I used the name of the location. My IDs look like this: `immunizenevada_org:Albertsons #1059`. Is this acceptable?

2. For the `fetched_from_uri` value I used the URL for the NV vaccine locator: `https://www.immunizenevada.org/covid-19-vaccine-locator`. That's not strictly accurate, since the data was actually fetched by POSTing to `https://www.immunizenevada.org/views/ajax`, but if you GET that url, you get a `404`. That seems less helpful, despite being technically accurate. Thoughts?