### PR TITLE
fix: normalized vaccine types

### DIFF
--- a/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
@@ -63,10 +63,10 @@ def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
     vaccines_field = site["attributes"]["flu_vaccinations"].lower().split(",")
 
     potentials = {
-        "pfizer": schema.Vaccine(vaccine="pfizer"),
+        "pfizer": schema.Vaccine(vaccine="pfizer_biontech"),
         "moderna": schema.Vaccine(vaccine="moderna"),
-        "janssen": schema.Vaccine(vaccine="janssen"),
-        "jjj": schema.Vaccine(vaccine="janssen"),
+        "janssen": schema.Vaccine(vaccine="johnson_johnson_janssen"),
+        "jjj": schema.Vaccine(vaccine="johnson_johnson_janssen"),
     }
 
     inventory = []

--- a/vaccine_feed_ingest/runners/az/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/az/arcgis/normalize.py
@@ -220,11 +220,11 @@ def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
 
     return [
         {
-            "Pfizer_BioNTech": schema.Vaccine(vaccine="pfizer"),
-            "Pfizer-BioNTech": schema.Vaccine(vaccine="pfizer"),
-            "Pfizer": schema.Vaccine(vaccine="pfizer"),
+            "Pfizer_BioNTech": schema.Vaccine(vaccine="pfizer_biontech"),
+            "Pfizer-BioNTech": schema.Vaccine(vaccine="pfizer_biontech"),
+            "Pfizer": schema.Vaccine(vaccine="pfizer_biontech"),
             "Moderna": schema.Vaccine(vaccine="moderna"),
-            "J_J": schema.Vaccine(vaccine="janssen"),
+            "J_J": schema.Vaccine(vaccine="johnson_johnson_janssen"),
         }[vaccine.lstrip("\u200b").strip()]
         for vaccine in inventory
     ]

--- a/vaccine_feed_ingest/runners/ny/am_i_eligible_covid19vaccine_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ny/am_i_eligible_covid19vaccine_gov/normalize.py
@@ -24,10 +24,10 @@ def _get_inventory(raw: str) -> Optional[List[schema.Vaccine]]:
     # we've only seen "Pfizer", but no reason not to use the rest of the
     # potentials from `ak/arcgis/normalize.py`
     potentials = {
-        "pfizer": schema.Vaccine(vaccine="pfizer"),
+        "pfizer": schema.Vaccine(vaccine="pfizer_biontech"),
         "moderna": schema.Vaccine(vaccine="moderna"),
-        "janssen": schema.Vaccine(vaccine="janssen"),
-        "jjj": schema.Vaccine(vaccine="janssen"),
+        "janssen": schema.Vaccine(vaccine="johnson_johnson_janssen"),
+        "jjj": schema.Vaccine(vaccine="johnson_johnson_janssen"),
     }
     try:
         return [potentials[raw.lower()]]


### PR DESCRIPTION
With the [vaccine type enum](https://github.com/CAVaccineInventory/vaccine-feed-ingest/wiki/Normalized-Location-Schema#vaccine-type-enum) now specified, fix existing normalizers to use values from the enum.

We will need to fix this again as PRs get merged in the coming days, but in the meantime let's get the files used as examples showing the new values!