### PR TITLE
Add path support to the shared json_list parser

### DIFF
--- a/vaccine_feed_ingest/runners/_shared/parse.py
+++ b/vaccine_feed_ingest/runners/_shared/parse.py
@@ -93,6 +93,9 @@ elif config["parser"] == "json_list":
         with in_filepath.open() as fin:
             json_list = json.load(fin)
 
+        for path_element in config.get("path", []):
+            json_list = json_list[path_element]
+
         out_filepath = _get_out_filepath(in_filepath, OUTPUT_DIR)
         _log_activity(config["state"], config["site"], in_filepath, out_filepath)
 


### PR DESCRIPTION
Allows the parser to work even when the location list is not top-level JSON. For example, if the JSON file contains `[{"locations":[...actual list of locations...]}]`, the following parse.yml file would work:

```yaml
---
state: ...
site: ...
parser: json_list
path: [0, "locations"]
```

This will be useful for the il/juvare parser. If this is merged, the [wiki page](https://github.com/CAVaccineInventory/vaccine-feed-ingest/wiki/JSON-to-NDJSON-Parser) should also be updated.