### PR TITLE
Validate stage outputs with the option to turn off

### DIFF
--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -53,6 +53,14 @@ def _dry_run_option() -> Callable:
     return click.option("--dry-run/--no-dry-run", type=bool, default=False)
 
 
+def _validate_option() -> Callable:
+    return click.option(
+        "--validate/--no-validate",
+        type=bool,
+        default=lambda: os.environ.get("ENABLE_VALIDATE", "true").lower() == "true",
+    )
+
+
 def _state_option() -> Callable:
     return click.option("--state", "state", type=str)
 
@@ -109,11 +117,13 @@ def fetch(
 @cli.command()
 @_state_option()
 @_output_dir_option()
+@_validate_option()
 @_dry_run_option()
 @_sites_argument()
 def parse(
     state: Optional[str],
     output_dir: pathlib.Path,
+    validate: bool,
     dry_run: bool,
     sites: Optional[Sequence[str]],
 ) -> None:
@@ -122,17 +132,19 @@ def parse(
     site_dirs = site.get_site_dirs(state, sites)
 
     for site_dir in site_dirs:
-        ingest.run_parse(site_dir, output_dir, timestamp, dry_run)
+        ingest.run_parse(site_dir, output_dir, timestamp, validate, dry_run)
 
 
 @cli.command()
 @_state_option()
 @_output_dir_option()
+@_validate_option()
 @_dry_run_option()
 @_sites_argument()
 def normalize(
     state: Optional[str],
     output_dir: pathlib.Path,
+    validate: bool,
     dry_run: bool,
     sites: Optional[Sequence[str]],
 ) -> None:
@@ -141,15 +153,19 @@ def normalize(
     site_dirs = site.get_site_dirs(state, sites)
 
     for site_dir in site_dirs:
-        ingest.run_normalize(site_dir, output_dir, timestamp, dry_run)
+        ingest.run_normalize(site_dir, output_dir, timestamp, validate, dry_run)
 
 
 @cli.command()
 @_state_option()
+@_validate_option()
 @_output_dir_option()
 @_sites_argument()
 def all_stages(
-    state: Optional[str], output_dir: pathlib.Path, sites: Optional[Sequence[str]]
+    state: Optional[str],
+    validate: bool,
+    output_dir: pathlib.Path,
+    sites: Optional[Sequence[str]],
 ) -> None:
     """Run all stages in succession for specified sites."""
     timestamp = _generate_run_timestamp()
@@ -161,12 +177,12 @@ def all_stages(
         if not fetch_success:
             continue
 
-        parse_success = ingest.run_parse(site_dir, output_dir, timestamp)
+        parse_success = ingest.run_parse(site_dir, output_dir, timestamp, validate)
 
         if not parse_success:
             continue
 
-        ingest.run_normalize(site_dir, output_dir, timestamp)
+        ingest.run_normalize(site_dir, output_dir, timestamp, validate)
 
 
 @cli.command()

--- a/vaccine_feed_ingest/stages/common.py
+++ b/vaccine_feed_ingest/stages/common.py
@@ -30,3 +30,10 @@ STAGE_OUTPUT_NAME = {
     PipelineStage.PARSE: "parsed",
     PipelineStage.NORMALIZE: "normalized",
 }
+
+
+# Directory name for where to store data for each stage
+STAGE_OUTPUT_SUFFIX = {
+    PipelineStage.PARSE: ".parsed.ndjson",
+    PipelineStage.NORMALIZE: ".normalized.ndjson",
+}

--- a/vaccine_feed_ingest/stages/ingest.py
+++ b/vaccine_feed_ingest/stages/ingest.py
@@ -10,7 +10,7 @@ import pydantic
 from vaccine_feed_ingest.schema import schema
 
 from . import outputs, site
-from .common import RUNNERS_DIR, PipelineStage, STAGE_OUTPUT_SUFFIX
+from .common import RUNNERS_DIR, STAGE_OUTPUT_SUFFIX, PipelineStage
 
 logger = logging.getLogger("ingest")
 

--- a/vaccine_feed_ingest/stages/ingest.py
+++ b/vaccine_feed_ingest/stages/ingest.py
@@ -139,7 +139,10 @@ def run_parse(
             parse_output_dir, suffix=STAGE_OUTPUT_SUFFIX[PipelineStage.PARSE]
         ):
             logger.warning(
-                "%s for %s returned no data files.", parse_path.name, site_dir.name
+                "%s for %s returned no data files with expected extension %s.",
+                parse_path.name,
+                site_dir.name,
+                STAGE_OUTPUT_SUFFIX[PipelineStage.PARSE],
             )
             return False
 
@@ -188,8 +191,14 @@ def run_normalize(
         )
         return False
 
-    if not outputs.data_exists(parse_run_dir):
-        logger.warning("No parse data available to normalize for %s.", site_dir.name)
+    if not outputs.data_exists(
+        parse_run_dir, suffix=STAGE_OUTPUT_SUFFIX[PipelineStage.PARSE]
+    ):
+        logger.warning(
+            "No parse data available to normalize for %s with extension %s.",
+            site_dir.name,
+            STAGE_OUTPUT_SUFFIX[PipelineStage.PARSE],
+        )
         return False
 
     with tempfile.TemporaryDirectory(
@@ -210,9 +219,14 @@ def run_normalize(
             check=True,
         )
 
-        if not outputs.data_exists(normalize_output_dir):
+        if not outputs.data_exists(
+            normalize_output_dir, suffix=STAGE_OUTPUT_SUFFIX[PipelineStage.NORMALIZE]
+        ):
             logger.warning(
-                "%s for %s returned no data files.", normalize_path.name, site_dir.name
+                "%s for %s returned no data files with expected extension %s.",
+                normalize_path.name,
+                site_dir.name,
+                STAGE_OUTPUT_SUFFIX[PipelineStage.NORMALIZE],
             )
             return False
 

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -13,7 +13,7 @@ from vaccine_feed_ingest.schema import schema
 
 from ..utils.match import canonicalize_address, get_full_address
 from . import outputs
-from .common import PipelineStage, STAGE_OUTPUT_SUFFIX
+from .common import STAGE_OUTPUT_SUFFIX, PipelineStage
 
 logger = logging.getLogger("load")
 

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -13,7 +13,7 @@ from vaccine_feed_ingest.schema import schema
 
 from ..utils.match import canonicalize_address, get_full_address
 from . import outputs
-from .common import PipelineStage
+from .common import PipelineStage, STAGE_OUTPUT_SUFFIX
 
 logger = logging.getLogger("load")
 
@@ -43,26 +43,27 @@ def run_load_to_vial(
         )
         return None
 
-    if not outputs.data_exists(normalize_run_dir):
+    if not outputs.data_exists(
+        normalize_run_dir, suffix=STAGE_OUTPUT_SUFFIX[PipelineStage.NORMALIZE]
+    ):
         logger.warning("No normalize data available to load for %s.", site_dir.name)
         return None
 
     num_imported_locations = 0
 
-    for filepath in outputs.iter_data_paths(normalize_run_dir):
-        if not filepath.name.endswith(".normalized.ndjson"):
-            continue
-
+    for filepath in outputs.iter_data_paths(
+        normalize_run_dir, suffix=STAGE_OUTPUT_SUFFIX[PipelineStage.NORMALIZE]
+    ):
         import_locations = []
-        with filepath.open("rb") as src_file:
+        with filepath.open() as src_file:
             for line in src_file:
                 try:
                     normalized_location = schema.NormalizedLocation.parse_raw(line)
-                except pydantic.ValidationError:
+                except pydantic.ValidationError as e:
                     logger.warning(
-                        "Skipping source location because it is invalid: %s",
+                        "Skipping source location because it is invalid: %s\n%s",
                         line,
-                        exc_info=True,
+                        str(e),
                     )
                     continue
 

--- a/vaccine_feed_ingest/stages/outputs.py
+++ b/vaccine_feed_ingest/stages/outputs.py
@@ -49,8 +49,8 @@ def generate_run_dir(
     return base_output_dir / state / site / STAGE_OUTPUT_NAME[stage] / timestamp
 
 
-def iter_data_paths(data_dir: pathlib.Path) -> Iterator[pathlib.Path]:
-    """Return paths to data files in data_dir.
+def iter_data_paths(data_dir: pathlib.Path, suffix: Optional[str] = None) -> Iterator[pathlib.Path]:
+    """Return paths to data files in data_dir with suffix.
 
     Directories and files that start with `_` or `.` are ignored.
     """
@@ -58,14 +58,18 @@ def iter_data_paths(data_dir: pathlib.Path) -> Iterator[pathlib.Path]:
         if filepath.name.startswith("_") or filepath.name.startswith("."):
             continue
 
+        if suffix and not filepath.name.endswith(suffix):
+            continue
+
         yield filepath
 
 
-def data_exists(data_dir: pathlib.Path) -> bool:
-    """Returns true if there are data files in data_dir.
+def data_exists(data_dir: pathlib.Path, suffix: Optional[str] = None) -> bool:
+    """Returns true if there are data files in data_dir with suffix.
 
-    Directories and files that start with `_` or `.` are ignored."""
-    return bool(next(iter_data_paths(data_dir), None))
+    Directories and files that start with `_` or `.` are ignored.
+    """
+    return bool(next(iter_data_paths(data_dir, suffix=suffix), None))
 
 
 def copy_files(src_dir: pathlib.Path, dst_dir: pathlib.Path) -> None:

--- a/vaccine_feed_ingest/stages/outputs.py
+++ b/vaccine_feed_ingest/stages/outputs.py
@@ -49,7 +49,9 @@ def generate_run_dir(
     return base_output_dir / state / site / STAGE_OUTPUT_NAME[stage] / timestamp
 
 
-def iter_data_paths(data_dir: pathlib.Path, suffix: Optional[str] = None) -> Iterator[pathlib.Path]:
+def iter_data_paths(
+    data_dir: pathlib.Path, suffix: Optional[str] = None
+) -> Iterator[pathlib.Path]:
     """Return paths to data files in data_dir with suffix.
 
     Directories and files that start with `_` or `.` are ignored.


### PR DESCRIPTION
Validate the outputs of parse and normalize stages to ensure they match the spec.

Does not upload them if they failed.

This can be turned off with `--no-validate` or `ENABLE_VALIDATE=false`