### PR TITLE
FYI Import source locations to VIAL in batches of 1k

### DIFF
--- a/vaccine_feed_ingest/vial.py
+++ b/vaccine_feed_ingest/vial.py
@@ -69,16 +69,17 @@ def import_source_locations(
     import_locations: Iterable[schema.ImportSourceLocation],
 ) -> urllib3.response.HTTPResponse:
     """Import source locations"""
-    encoded_ndjson = "\n".join(
-        [loc.json(exclude_none=True) for loc in import_locations]
-    )
+    for import_locations_batch in misc.batch(import_locations, 1_000):
+        encoded_ndjson = "\n".join(
+            [loc.json(exclude_none=True) for loc in import_locations_batch]
+        )
 
-    return vial_http.request(
-        "POST",
-        f"/api/importSourceLocations?import_run_id={import_run_id}",
-        headers={**vial_http.headers, "Content-Type": "application/x-ndjson"},
-        body=encoded_ndjson.encode("utf-8"),
-    )
+        return vial_http.request(
+            "POST",
+            f"/api/importSourceLocations?import_run_id={import_run_id}",
+            headers={**vial_http.headers, "Content-Type": "application/x-ndjson"},
+            body=encoded_ndjson.encode("utf-8"),
+        )
 
 
 def search_locations(


### PR DESCRIPTION
There is a max size for POSTs of `32MB` so we need to batch imports. I picked batching of `1,000` records because it is low enough that it will be well under `32MB` and high enough that many feeds will only have one batch.