### PR TITLE
docs(pr): suggest autoformatting runners dir only

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,5 +18,5 @@ Site: <!-- name of site, like vaccinespotter_org or arcgis--> |
 ## Before Opening a PR
 - [ ] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
 - [ ] I ran auto-formatting:
-  - [ ] `poetry run black vaccine_feed_ingest`
-  - [ ] `poetry run isort vaccine_feed_ingest`
+  - [ ] `poetry run black vaccine_feed_ingest/runners`
+  - [ ] `poetry run isort vaccine_feed_ingest/runners`


### PR DESCRIPTION
Currently there is a config issue where `isort` locally adds newlines which are rejected by `isort` in SuperLinter (#208).

For now, prompt contributors to run the auto-formatters only on the `runners` dir to avoid this issue for most contributions.