### PR TITLE
Ca metrolink parse

### DIFF
--- a/vaccine_feed_ingest/runners/ca/metrolink/parse.py
+++ b/vaccine_feed_ingest/runners/ca/metrolink/parse.py
@@ -27,8 +27,11 @@ for filename in input_filenames:
         longname = str(cells[0].renderContents())[2:-1]
         site_name = longname.split(" <br/> ")[0]
         address_tokens = re.search("(.*), (.*)", longname.split(" <br/> ")[1])
-        site_address = address_tokens.group(1)
-        site_city = address_tokens.group(2)
+
+        site_address, site_city = None, None
+        if address_tokens is not None:
+            site_address = address_tokens.group(1)
+            site_city = address_tokens.group(2)
 
         site = {
             "name": site_name,

--- a/vaccine_feed_ingest/runners/ca/metrolink/parse.py
+++ b/vaccine_feed_ingest/runners/ca/metrolink/parse.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 import json
+import os
 import pathlib
 import sys
-import os
 
 from bs4 import BeautifulSoup
 
@@ -14,24 +14,26 @@ input_filenames = [p for p in pathlib.Path(input_dir).iterdir() if p.is_file()]
 
 for filename in input_filenames:
     sites = []
-    
+
     with filename.open() as fin:
         content = fin.read()
-    
+
     soup = BeautifulSoup(content, "html.parser")
-    table = soup.find(id='vaxLocationsTable')
+    table = soup.find(id="vaxLocationsTable")
     for row in table.find("tbody").find_all("tr"):
         cells = row.find_all("td")
-        
+
         site = {
-            "site_name": str(cells[0].renderContents())[2:-1].split(' <br/> ')[0],
-            "site_address": str(cells[0].renderContents())[2:-1].split(' <br/> ')[1],
+            "site_name": str(cells[0].renderContents())[2:-1].split(" <br/> ")[0],
+            "site_address": str(cells[0].renderContents())[2:-1].split(" <br/> ")[1],
             "metrolink_line": cells[1].string,
             "metrolink_station": cells[2].string,
         }
         sites.append(site)
-    
-    with (output_dir / (os.path.basename(filename) + '.parsed.ndjson')).open('w') as fout:
+
+    with (output_dir / (os.path.basename(filename) + ".parsed.ndjson")).open(
+        "w"
+    ) as fout:
         for site in sites:
             json.dump(site, fout)
-            fout.write('\n')
+            fout.write("\n")

--- a/vaccine_feed_ingest/runners/ca/metrolink/parse.py
+++ b/vaccine_feed_ingest/runners/ca/metrolink/parse.py
@@ -7,8 +7,6 @@ import os
 
 from bs4 import BeautifulSoup
 
-import re
-
 input_dir = pathlib.Path(sys.argv[2])
 output_dir = pathlib.Path(sys.argv[1])
 
@@ -33,8 +31,7 @@ for filename in input_filenames:
         }
         sites.append(site)
     
-    print(os.path.basename(filename))
     with (output_dir / (os.path.basename(filename) + '.parsed.ndjson')).open('w') as fout:
         for site in sites:
-            fout.write(str(site))
+            json.dump(site, fout)
             fout.write('\n')

--- a/vaccine_feed_ingest/runners/ca/metrolink/parse.py
+++ b/vaccine_feed_ingest/runners/ca/metrolink/parse.py
@@ -3,11 +3,10 @@
 import json
 import os
 import pathlib
+import re
 import sys
 
 from bs4 import BeautifulSoup
-
-import re
 
 input_dir = pathlib.Path(sys.argv[2])
 output_dir = pathlib.Path(sys.argv[1])
@@ -24,13 +23,13 @@ for filename in input_filenames:
     table = soup.find(id="vaxLocationsTable")
     for row in table.find("tbody").find_all("tr"):
         cells = row.find_all("td")
-        
+
         longname = str(cells[0].renderContents())[2:-1]
         site_name = longname.split(" <br/> ")[0]
         address_tokens = re.search("(.*), (.*)", longname.split(" <br/> ")[1])
         site_address = address_tokens.group(1)
         site_city = address_tokens.group(2)
-        
+
         site = {
             "name": site_name,
             "address": site_address,

--- a/vaccine_feed_ingest/runners/ca/metrolink/parse.py
+++ b/vaccine_feed_ingest/runners/ca/metrolink/parse.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import json
+import pathlib
+import sys
+import os
+
+from bs4 import BeautifulSoup
+
+import re
+
+input_dir = pathlib.Path(sys.argv[2])
+output_dir = pathlib.Path(sys.argv[1])
+
+input_filenames = [p for p in pathlib.Path(input_dir).iterdir() if p.is_file()]
+
+for filename in input_filenames:
+    sites = []
+    
+    with filename.open() as fin:
+        content = fin.read()
+    
+    soup = BeautifulSoup(content, "html.parser")
+    table = soup.find(id='vaxLocationsTable')
+    for row in table.find("tbody").find_all("tr"):
+        cells = row.find_all("td")
+        
+        site = {
+            "site_name": str(cells[0].renderContents())[2:-1].split(' <br/> ')[0],
+            "site_address": str(cells[0].renderContents())[2:-1].split(' <br/> ')[1],
+            "metrolink_line": cells[1].string,
+            "metrolink_station": cells[2].string,
+        }
+        sites.append(site)
+    
+    print(os.path.basename(filename))
+    with (output_dir / (os.path.basename(filename) + '.parsed.ndjson')).open('w') as fout:
+        for site in sites:
+            fout.write(str(site))
+            fout.write('\n')

--- a/vaccine_feed_ingest/runners/ca/metrolink/parse.py
+++ b/vaccine_feed_ingest/runners/ca/metrolink/parse.py
@@ -7,6 +7,8 @@ import sys
 
 from bs4 import BeautifulSoup
 
+import re
+
 input_dir = pathlib.Path(sys.argv[2])
 output_dir = pathlib.Path(sys.argv[1])
 
@@ -22,10 +24,17 @@ for filename in input_filenames:
     table = soup.find(id="vaxLocationsTable")
     for row in table.find("tbody").find_all("tr"):
         cells = row.find_all("td")
-
+        
+        longname = str(cells[0].renderContents())[2:-1]
+        site_name = longname.split(" <br/> ")[0]
+        address_tokens = re.search("(.*), (.*)", longname.split(" <br/> ")[1])
+        site_address = address_tokens.group(1)
+        site_city = address_tokens.group(2)
+        
         site = {
-            "site_name": str(cells[0].renderContents())[2:-1].split(" <br/> ")[0],
-            "site_address": str(cells[0].renderContents())[2:-1].split(" <br/> ")[1],
+            "name": site_name,
+            "address": site_address,
+            "city": site_city,
             "metrolink_line": cells[1].string,
             "metrolink_station": cells[2].string,
         }


### PR DESCRIPTION
# parse metrolink for ca

| Key Details |
|-|
| Resolves #178 |
State: ca |
Site: metrolink |

## Notes
uses bs4 to parse table. raw file includes only site name, address, metrolink line, metrolink station.

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```json
{"site_name": "Pomona Fairplex (Gate 15)", "site_address": "2352 Arrow Hwy., Pomona", "metrolink_line": "San Bernardino", "metrolink_station": "Pomona - North"}
{"site_name": "Cal State Northridge", "site_address": "18343 Plummer Street, Northridge", "metrolink_line": "Ventura County", "metrolink_station": "Northridge"}
{"site_name": "El Sereno Recreation Center", "site_address": "4721 Klamath St., Los Angeles", "metrolink_line": "San Bernardino", "metrolink_station": "Cal State L.A."}
{"site_name": "St. John's Well Child and Family-Lincoln", "site_address": "2515 Alta St., Los Angeles", "metrolink_line": "Union Station", "metrolink_station": "Union Station"}
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting:
  - [x] `poetry run black vaccine_feed_ingest/runners`
  - [x] `poetry run isort vaccine_feed_ingest/runners`