### PR TITLE
Add a tox lint-fix command

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,4 @@ Site: <!-- name of site, like vaccinespotter_org or arcgis--> |
 
 ## Before Opening a PR
 - [ ] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
-- [ ] I ran auto-formatting:
-  - [ ] `poetry run black vaccine_feed_ingest/runners`
-  - [ ] `poetry run isort vaccine_feed_ingest/runners`
+- [ ] I ran auto-formatting: `poetry run tox -e lint-fix`

--- a/tox.ini
+++ b/tox.ini
@@ -14,18 +14,6 @@ basepython = python3
 [testenv]
 whitelist_externals = poetry
 install_command = poetry install --quiet --extras {packages} --no-root --no-interaction
-deps =
-  lint test
-setenv =
-  VIAL_APIKEY = test_api_key
-  VIAL_SERVER = http://localhost:8080
-  OUTPUT_DIR = test_out
-commands=
-  poetry run flake8 vaccine_feed_ingest
-  poetry run isort vaccine_feed_ingest --check-only
-  poetry run black vaccine_feed_ingest --diff --check
-  poetry run mypy vaccine_feed_ingest
-  poetry run pytest tests
 
 
 [testenv:lint]
@@ -35,6 +23,16 @@ commands =
   poetry run flake8 vaccine_feed_ingest
   poetry run isort vaccine_feed_ingest --check-only
   poetry run black vaccine_feed_ingest --diff --check
+  poetry run mypy vaccine_feed_ingest
+
+
+[testenv:lint-fix]
+deps =
+  lint
+commands =
+  poetry run flake8 vaccine_feed_ingest
+  poetry run isort vaccine_feed_ingest
+  poetry run black vaccine_feed_ingest
   poetry run mypy vaccine_feed_ingest
 
 


### PR DESCRIPTION
Add a tox command that fixes lint errors instead of failing:
```
poetry run tox -e lint-fix
```

This command should be used locally, but not for an automation.