### PR TITLE
Issue #210: fix fetch and parse computation for arcgis sites

### DIFF
--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -82,8 +82,9 @@ def available_sites(state: Optional[str]) -> None:
     """Print list of available sites, optionally filtered by state"""
 
     for site_dir in site.get_site_dirs_for_state(state):
-        has_fetch = bool(site.find_executeable(site_dir, common.PipelineStage.FETCH))
-        has_parse = bool(site.find_executeable(site_dir, common.PipelineStage.PARSE))
+        is_arcgis_site = site_dir.name.endswith('arcgis')
+        has_fetch = _compute_has_fetch(site_dir, is_arcgis_site)
+        has_parse = _compute_has_parse(site_dir, is_arcgis_site)
         has_normalize = bool(
             site.find_executeable(site_dir, common.PipelineStage.NORMALIZE)
         )
@@ -94,6 +95,20 @@ def available_sites(state: Optional[str]) -> None:
             "parse" if has_parse else "no-parse",
             "normalize" if has_normalize else "no-normalize",
         )
+
+
+def _compute_has_fetch(site_dir: str, is_arcgis_site: bool) -> bool:
+    if is_arcgis_site:
+        return bool(site.find_yml(site_dir, common.PipelineStage.FETCH))
+    else:
+        return bool(site.find_executeable(site_dir, common.PipelineStage.FETCH))
+
+
+def _compute_has_parse(site_dir: str, is_arcgis_site: bool) -> bool:
+    if is_arcgis_site:
+        return bool(site.find_yml(site_dir, common.PipelineStage.PARSE))
+    else:
+        return bool(site.find_executeable(site_dir, common.PipelineStage.PARSE))
 
 
 @cli.command()

--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -82,9 +82,8 @@ def available_sites(state: Optional[str]) -> None:
     """Print list of available sites, optionally filtered by state"""
 
     for site_dir in site.get_site_dirs_for_state(state):
-        is_arcgis_site = site_dir.name.endswith('arcgis')
-        has_fetch = _compute_has_fetch(site_dir, is_arcgis_site)
-        has_parse = _compute_has_parse(site_dir, is_arcgis_site)
+        has_fetch = _compute_has_fetch(site_dir)
+        has_parse = _compute_has_parse(site_dir)
         has_normalize = bool(
             site.find_executeable(site_dir, common.PipelineStage.NORMALIZE)
         )
@@ -97,18 +96,28 @@ def available_sites(state: Optional[str]) -> None:
         )
 
 
-def _compute_has_fetch(site_dir: str, is_arcgis_site: bool) -> bool:
-    if is_arcgis_site:
-        return bool(site.find_yml(site_dir, common.PipelineStage.FETCH))
-    else:
-        return bool(site.find_executeable(site_dir, common.PipelineStage.FETCH))
+def _compute_has_fetch(site_dir: pathlib.Path) -> bool:
+    if site.find_executeable(site_dir, common.PipelineStage.FETCH):
+        return True
+    if not site.find_yml(site_dir, common.PipelineStage.FETCH):
+        return False
+    return bool(
+        site.find_executeable(
+            common.RUNNERS_DIR.joinpath("_shared"), common.PipelineStage.FETCH
+        )
+    )
 
 
-def _compute_has_parse(site_dir: str, is_arcgis_site: bool) -> bool:
-    if is_arcgis_site:
-        return bool(site.find_yml(site_dir, common.PipelineStage.PARSE))
-    else:
-        return bool(site.find_executeable(site_dir, common.PipelineStage.PARSE))
+def _compute_has_parse(site_dir: pathlib.Path) -> bool:
+    if site.find_executeable(site_dir, common.PipelineStage.PARSE):
+        return True
+    if not site.find_yml(site_dir, common.PipelineStage.PARSE):
+        return False
+    return bool(
+        site.find_executeable(
+            common.RUNNERS_DIR.joinpath("_shared"), common.PipelineStage.PARSE
+        )
+    )
 
 
 @cli.command()


### PR DESCRIPTION
# <!-- <stage> <site> for <state> (e.g.,  Normalize ArcGIS for MD) -->

| Key Details |
|-|
| Resolves #210 |
State:  |
Site:  |

## Notes

A straightforward fix to how `fetch` and `parse` statuses are computed for arcgis based sources, as seen when running the following command:

```
poetry run vaccine-feed-ingest available-sites
```

## Data sample

Before this fix, the output for arcgis sites looked like this:

```
ak/arcgis no-fetch no-parse normalize
```

(even though Alaska has valid fetch and parse yml files). After this fix, the output looks correct:

```
ak/arcgis fetch parse normalize
```
I also verified that none of the output changes for non-arcgis sites.

## Before Opening a PR
- [x] I tested this using the CLI; I ran: `poetry run vaccine-feed-ingest all-stages ak/arcgis`
- [x] I ran auto-formatting:
  - [ ] `poetry run black vaccine_feed_ingest/runners`
  - [ ] `poetry run isort vaccine_feed_ingest/runners`
