### PR TITLE
Fix Access schema with wheelchair enum

### DIFF
--- a/vaccine_feed_ingest/runners/ca/sf_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ca/sf_gov/normalize.py
@@ -48,7 +48,7 @@ def normalize(site: dict, timestamp: str) -> dict:
         "access": {
             "walk": site["access_mode"]["walk"],
             "drive": site["access_mode"]["drive"],
-            "wheelchair": site["access"]["wheelchair"],
+            "wheelchair": "yes" if site["access"]["wheelchair"] else "no",
         },
         "languages": [k for k, v in site["access"]["languages"].items() if v],
         "links": [

--- a/vaccine_feed_ingest/schema/schema.py
+++ b/vaccine_feed_ingest/schema/schema.py
@@ -108,12 +108,12 @@ class Access(BaseModel):
     {
         "walk": bool,
         "drive": bool,
-        "wheelchair": bool,
+        "wheelchair": str,
     }
     """
 
-    walk: Optional[str]
-    drive: Optional[str]
+    walk: Optional[bool]
+    drive: Optional[bool]
     wheelchair: Optional[str]
 
 


### PR DESCRIPTION
1. Change wheelchair to be an enum of `yes`, `partial`, `no`
2. Fix `walk` and `drive` to be bool like in the spec.

Change `sf_gov` to produce wheelchair enum values. It is the only one using the schema right now.