### PR TITLE
refactor: use external schema

### DIFF
--- a/.github/ISSUE_TEMPLATE/runner-normalize.md
+++ b/.github/ISSUE_TEMPLATE/runner-normalize.md
@@ -9,7 +9,7 @@ assignees: ''
 
 [![learn our pipeline: normalize](https://img.shields.io/static/v1?label=learn%20our%20pipeline&message=normalize&style=social)](https://github.com/CAVaccineInventory/vaccine-feed-ingest/wiki/Runner-pipeline-stages#normalize)
 
-Normalize existing [`.ndjson`](http://ndjson.org/) records into [the Vaccinate The States data schema](https://github.com/CAVaccineInventory/vaccine-feed-ingest/blob/main/vaccine_feed_ingest/schema/schema.py).
+Normalize existing [`.ndjson`](http://ndjson.org/) records into [the Vaccinate The States data schema](https://github.com/CAVaccineInventory/vaccine-feed-ingest/wiki/Normalized-Location-Schema).
 
 Read all files in the directory passed as the second argument (`sys.argv[2]`), transform each record into the normalized schema (filling in as much detail as possible), then output them to new files in the directory passed as the first argument (`sys.argv[1]`).
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1793,6 +1793,21 @@ python-versions = "*"
 jellyfish = "0.6.1"
 
 [[package]]
+name = "vaccine-feed-ingest-schema"
+version = "0.1"
+description = "Normalized data schema for the output of the vaccine-feed-ingest pipeline."
+category = "main"
+optional = false
+python-versions = ">=3.9"
+
+[package.dependencies]
+pydantic = "*"
+
+[package.extras]
+lint = ["flake8", "black", "mypy", "isort"]
+test = ["pytest"]
+
+[[package]]
 name = "virtualenv"
 version = "20.4.4"
 description = "Virtual Python Environment builder"
@@ -1867,12 +1882,12 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 
 [extras]
 lint = ["flake8", "black", "mypy", "isort"]
-test = ["pytest"]
+test = ["pytest", "pytest-runner"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "db1b29ed28b4eda468bb7458aed58f7f5b57e09b93449374d77a64fca9981430"
+content-hash = "7a73d358d65640cbbbfd0df922f392d63cd5b2e9bb73763e428416f4c6b7aee0"
 
 [metadata.files]
 anyio = [
@@ -3024,6 +3039,10 @@ urllib3 = [
 ]
 us = [
     {file = "us-2.0.2.tar.gz", hash = "sha256:cb11ad0d43deff3a1c3690c74f0c731cff5b862c73339df2edd91133e1496fbc"},
+]
+vaccine-feed-ingest-schema = [
+    {file = "vaccine-feed-ingest-schema-0.1.tar.gz", hash = "sha256:f84963aac8b1a72da1d8f5d2c834251a78ad3de116110f76982442eb5b8f4758"},
+    {file = "vaccine_feed_ingest_schema-0.1-py3-none-any.whl", hash = "sha256:b666618ee144ce85324bed756d768f6671f5dc792f9b84b4d1690dcc372bbbaf"},
 ]
 virtualenv = [
     {file = "virtualenv-20.4.4-py2.py3-none-any.whl", hash = "sha256:a935126db63128861987a7d5d30e23e8ec045a73840eeccb467c148514e29535"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ pandas = "^1.2.4"
 openpyxl = "^3.0.7"
 pytz = "^2021.1"
 beautifulsoup4 = "^4.9.3"
+vaccine-feed-ingest-schema = "^0.1"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.23.0"

--- a/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
@@ -9,7 +9,7 @@ import re
 import sys
 from typing import List, Optional
 
-from vaccine_feed_ingest_schema import schema
+from vaccine_feed_ingest_schema import schema  # noqa: E402
 
 # Configure logger
 logging.basicConfig(

--- a/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
@@ -41,7 +41,7 @@ def _get_id(site: dict) -> str:
 
     # Could parse these from directory traversal, but do not for now to avoid
     # accidental mutation.
-    site = "arcgis"
+    site_name = "arcgis"
     runner = "ak"
 
     # Could parse these from the input file name, but do not for now to avoid
@@ -49,7 +49,7 @@ def _get_id(site: dict) -> str:
     arcgis = "d92cbd6ff2524d7e92bef109f30cb366"
     layer = 0
 
-    return f"{runner}:{site}:{arcgis}_{layer}:{data_id}"
+    return f"{runner}:{site_name}:{arcgis}_{layer}:{data_id}"
 
 
 def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:

--- a/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
@@ -9,14 +9,7 @@ import re
 import sys
 from typing import List, Optional
 
-# import schema
-site_dir = pathlib.Path(__file__).parent
-state_dir = site_dir.parent
-runner_dir = state_dir.parent
-root_dir = runner_dir.parent
-sys.path.append(str(root_dir))
-
-from schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import schema
 
 # Configure logger
 logging.basicConfig(

--- a/vaccine_feed_ingest/runners/az/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/az/arcgis/normalize.py
@@ -7,7 +7,7 @@ import pathlib
 import re
 import sys
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from vaccine_feed_ingest_schema import schema
 
@@ -32,7 +32,7 @@ def _get_id(site: dict) -> str:
 
     # Could parse these from directory traversal, but do not for now to avoid
     # accidental mutation.
-    site = "arcgis"
+    site_name = "arcgis"
     runner = "az"
 
     # Could parse these from the input file name, but do not for now to avoid
@@ -40,7 +40,7 @@ def _get_id(site: dict) -> str:
     arcgis = "128ead309d754558ad81bccd99188dc9"
     layer = 0
 
-    return f"{runner}:{site}:{arcgis}_{layer}:{data_id}"
+    return f"{runner}:{site_name}:{arcgis}_{layer}:{data_id}"
 
 
 def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:
@@ -106,7 +106,7 @@ def _get_opening_dates(site: dict) -> Optional[List[schema.OpenDate]]:
     ]
 
 
-def _parse_time(human_readable_time: str) -> (int, int):
+def _parse_time(human_readable_time: str) -> Tuple[int, int]:
     match = re.match(r"^(?P<hour>\d+):(?P<minute>\d+) ?AM?$", human_readable_time)
     if match:
         return int(match.group("hour")), int(match.group("minute"))

--- a/vaccine_feed_ingest/runners/az/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/az/arcgis/normalize.py
@@ -9,14 +9,7 @@ import sys
 from datetime import datetime
 from typing import List, Optional
 
-# import schema
-site_dir = pathlib.Path(__file__).parent
-state_dir = site_dir.parent
-runner_dir = state_dir.parent
-root_dir = runner_dir.parent
-sys.path.append(str(root_dir))
-
-from schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import schema
 
 # Configure logger
 logging.basicConfig(

--- a/vaccine_feed_ingest/runners/mo/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/mo/arcgis/normalize.py
@@ -9,14 +9,7 @@ import re
 import sys
 from typing import List, Optional
 
-# import schema
-site_dir = pathlib.Path(__file__).parent
-state_dir = site_dir.parent
-runner_dir = state_dir.parent
-root_dir = runner_dir.parent
-sys.path.append(str(root_dir))
-
-from schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import schema
 
 # Configure logger
 logging.basicConfig(

--- a/vaccine_feed_ingest/runners/mo/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/mo/arcgis/normalize.py
@@ -25,7 +25,7 @@ def _get_id(site: dict) -> str:
 
     # Could parse these from directory traversal, but do not for now to avoid
     # accidental mutation.
-    site = "arcgis"
+    site_name = "arcgis"
     runner = "mo"
 
     # Could parse these from the input file name, but do not for now to avoid
@@ -33,7 +33,7 @@ def _get_id(site: dict) -> str:
     arcgis = "46630b2520ce44a68a9f42f8343d3518"
     layer = 0
 
-    return f"{runner}:{site}:{arcgis}_{layer}:{data_id}"
+    return f"{runner}:{site_name}:{arcgis}_{layer}:{data_id}"
 
 
 def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:

--- a/vaccine_feed_ingest/runners/pa/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/pa/arcgis/normalize.py
@@ -25,7 +25,7 @@ def _get_id(site: dict) -> str:
 
     # Could parse these from directory traversal, but do not for now to avoid
     # accidental mutation.
-    site = "arcgis"
+    site_name = "arcgis"
     runner = "pa"
 
     # Could parse these from the input file name, but do not for now to avoid
@@ -33,7 +33,7 @@ def _get_id(site: dict) -> str:
     arcgis = "5b874ac0947347e9be49f6847eb44604"
     layer = 0
 
-    return f"{runner}:{site}:{arcgis}_{layer}:{data_id}"
+    return f"{runner}:{site_name}:{arcgis}_{layer}:{data_id}"
 
 
 def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:

--- a/vaccine_feed_ingest/runners/pa/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/pa/arcgis/normalize.py
@@ -9,14 +9,7 @@ import re
 import sys
 from typing import List, Optional
 
-# import schema
-site_dir = pathlib.Path(__file__).parent
-state_dir = site_dir.parent
-runner_dir = state_dir.parent
-root_dir = runner_dir.parent
-sys.path.append(str(root_dir))
-
-from schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import schema
 
 # Configure logger
 logging.basicConfig(

--- a/vaccine_feed_ingest/runners/ri/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ri/arcgis/normalize.py
@@ -25,7 +25,7 @@ def _get_id(site: dict) -> str:
 
     # Could parse these from directory traversal, but do not for now to avoid
     # accidental mutation.
-    site = "arcgis"
+    site_name = "arcgis"
     runner = "ri"
 
     # Could parse these from the input file name, but do not for now to avoid
@@ -33,7 +33,7 @@ def _get_id(site: dict) -> str:
     arcgis = "da57e8c8663048a2a9893c636fef63d0"
     layer = 0
 
-    return f"{runner}:{site}:{arcgis}_{layer}:{data_id}"
+    return f"{runner}:{site_name}:{arcgis}_{layer}:{data_id}"
 
 
 def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:

--- a/vaccine_feed_ingest/runners/ri/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ri/arcgis/normalize.py
@@ -9,14 +9,7 @@ import re
 import sys
 from typing import List, Optional
 
-# import schema
-site_dir = pathlib.Path(__file__).parent
-state_dir = site_dir.parent
-runner_dir = state_dir.parent
-root_dir = runner_dir.parent
-sys.path.append(str(root_dir))
-
-from schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import schema
 
 # Configure logger
 logging.basicConfig(

--- a/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
@@ -32,7 +32,7 @@ def _get_id(site: dict) -> str:
 
     # Could parse these from directory traversal, but do not for now to avoid
     # accidental mutation.
-    site = "arcgis"
+    site_name = "arcgis"
     runner = "sc"
 
     # Could parse these from the input file name, but do not for now to avoid
@@ -40,7 +40,7 @@ def _get_id(site: dict) -> str:
     arcgis = "bbd8924909264baaa1a5a1564b393063"
     layer = 0
 
-    return f"{runner}:{site}:{arcgis}_{layer}:{data_id}"
+    return f"{runner}:{site_name}:{arcgis}_{layer}:{data_id}"
 
 
 # This currently tosses any address if it doesn't have a street address or zip because

--- a/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
@@ -9,14 +9,7 @@ import re
 import sys
 from typing import List, Optional
 
-# import schema
-site_dir = pathlib.Path(__file__).parent
-state_dir = site_dir.parent
-runner_dir = state_dir.parent
-root_dir = runner_dir.parent
-sys.path.append(str(root_dir))
-
-from schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import schema
 
 # Configure logger
 logging.basicConfig(

--- a/vaccine_feed_ingest/schema/schema.py
+++ b/vaccine_feed_ingest/schema/schema.py
@@ -1,8 +1,26 @@
 #!/usr/bin/env python3
 
+import warnings
 from typing import List, Optional
 
 from pydantic import BaseModel
+
+"""
+DEPRECATION NOTICE
+vaccine_feed_ingest/schema/schema.py is DEPRECATED. Instead of using this file,
+import the published package using the line:
+
+from vaccine_feed_ingest_schema import schema
+
+This file is maintained in the source so that currently open PRs will not break.
+It will be removed from source by 2021-05-01, potentially earlier.
+"""
+warnings.warn(
+    "vaccine_feed_ingest/schema/schema.py is deprecated. Use the the published vaccine_feed_ingest_schema"
+    + "package instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 class Address(BaseModel):

--- a/vaccine_feed_ingest/stages/ingest.py
+++ b/vaccine_feed_ingest/stages/ingest.py
@@ -7,8 +7,8 @@ import subprocess
 import tempfile
 
 import pydantic
+from vaccine_feed_ingest_schema import schema
 
-from ..schema import schema
 from . import outputs, site
 from .common import RUNNERS_DIR, STAGE_OUTPUT_SUFFIX, PipelineStage
 

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -8,9 +8,9 @@ import rtree
 import shapely.geometry
 import urllib3
 import us
+from vaccine_feed_ingest_schema import schema
 
 from .. import vial
-from ..schema import schema
 from ..utils.match import canonicalize_address, get_full_address
 from . import outputs
 from .common import STAGE_OUTPUT_SUFFIX, PipelineStage

--- a/vaccine_feed_ingest/utils/match.py
+++ b/vaccine_feed_ingest/utils/match.py
@@ -1,10 +1,10 @@
 import re
 from typing import Optional
 
-from ..schema.schema import Address
+from vaccine_feed_ingest_schema import schema
 
 
-def get_full_address(address: Optional[Address]) -> str:
+def get_full_address(address: Optional[schema.Address]) -> str:
     if address is None:
         return ""
     if address.street2:

--- a/vaccine_feed_ingest/vial.py
+++ b/vaccine_feed_ingest/vial.py
@@ -10,8 +10,8 @@ import geojson
 import rtree
 import shapely.geometry
 import urllib3
+from vaccine_feed_ingest_schema import schema
 
-from .schema import schema
 from .utils import misc
 
 logger = logging.getLogger("vial")


### PR DESCRIPTION
[`vaccine-feed-ingest-schema` `v0.1.0`](https://github.com/CAVaccineInventory/vaccine-feed-ingest-schema/releases/tag/0.1) is a published version of the normalized schema from this repo.

Switch all present uses of the local schema to the published schema, and add a deprecation warning on use of the local schema.

I will also update [the `Normalized Location Schema` wiki page](https://github.com/CAVaccineInventory/vaccine-feed-ingest/wiki/Normalized-Location-Schema) to referenced the published package rather than the local file.

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
