### PR TITLE
normalize juvare for il

### DIFF
--- a/vaccine_feed_ingest/runners/il/juvare/normalize.py
+++ b/vaccine_feed_ingest/runners/il/juvare/normalize.py
@@ -56,7 +56,7 @@ def _get_building_and_address(site: dict) -> Tuple[str, Optional[schema.Address]
         r"""
         (?P<building>[^0-9]*)        # building name
         (?P<street>[0-9].*           # street address, must end with punctuation or street type
-          (\b(ave|avenue|blvd|boulevard|cir|circle|ct|court|dr|drive|hwy|highway|ln|lane|pkwy|parkway|st|street|way)\b\s*|[.,0-9]\s*|[\r\n])
+            (\b(ave|avenue|blvd|boulevard|cir|circle|ct|court|dr|drive|hwy|highway|ln|lane|pkwy|parkway|st|street|way)\b\s*|[.,0-9]\s*|[\r\n])
         )
         (?P<city>(\b\w+[ ]*)+)       # city
         [,]?\s+(IL|Illinois)\b[.,]?  # state
@@ -143,7 +143,7 @@ def _filter_name(building: str, site: dict) -> str:
                 and|to
                 |jan(uary)?|feb(ruary)?|mar(ch)?|apr(il)?|may|june?
                 |july?|aug(ust)?|sep(tember)?|oct(ober)?|nov(ember)?|dec(ember)?
-              )
+                )
             \b)+""",
         "",
         name,

--- a/vaccine_feed_ingest/runners/il/juvare/normalize.py
+++ b/vaccine_feed_ingest/runners/il/juvare/normalize.py
@@ -6,7 +6,7 @@ import json
 import pathlib
 import re
 import sys
-from typing import List
+from typing import List, Optional, Tuple
 
 from vaccine_feed_ingest.schema import schema  # noqa: E402
 
@@ -21,7 +21,7 @@ def _get_source(site: dict, timestamp: str) -> schema.Source:
     )
 
 
-def _parse_date(date: str) -> str:
+def _parse_date(date: str) -> Optional[str]:
     match = re.match(r"(\d+)/(\d+)/(\d+).*", date or "")
     if not match:
         return None
@@ -43,7 +43,7 @@ def _get_access(site: dict) -> schema.Access:
     return None
 
 
-def _get_building_and_address(site: dict) -> (str, schema.Address):
+def _get_building_and_address(site: dict) -> Tuple[str, Optional[schema.Address]]:
     # NOTE: some locations are missing the ZIP code. We return None for these
     # locations because the schema requires a ZIP code.
 
@@ -97,7 +97,7 @@ def _get_contact(site: dict) -> schema.Contact:
     return [schema.Contact(contact_type="booking", website=indirect_url)]
 
 
-def _get_inventory(site: dict) -> List[schema.Vaccine]:
+def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
     name = site["name"]
 
     inventory = []
@@ -215,7 +215,9 @@ def normalize(site: dict, timestamp: str) -> str:
     building, address = _get_building_and_address(site)
 
     if site["lat"] and site["lon"]:
-        location = {"latitude": site["lat"], "longitude": site["lon"]}
+        location: Optional[schema.LatLng] = schema.LatLng(
+            latitude=site["lat"], longitude=site["lon"]
+        )
     else:
         location = None
 

--- a/vaccine_feed_ingest/runners/il/juvare/normalize.py
+++ b/vaccine_feed_ingest/runners/il/juvare/normalize.py
@@ -8,7 +8,7 @@ import re
 import sys
 from typing import List, Optional, Tuple
 
-from vaccine_feed_ingest.schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import schema  # noqa: E402
 
 
 def _get_source(site: dict, timestamp: str) -> schema.Source:

--- a/vaccine_feed_ingest/runners/il/juvare/normalize.py
+++ b/vaccine_feed_ingest/runners/il/juvare/normalize.py
@@ -110,9 +110,9 @@ def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
         inventory.append(
             schema.Vaccine(vaccine="pfizer_biontech", supply_level="in_stock")
         )
-    elif moderna:
+    if moderna:
         inventory.append(schema.Vaccine(vaccine="moderna", supply_level="in_stock"))
-    elif johnson:
+    if johnson:
         inventory.append(
             schema.Vaccine(vaccine="johnson_johnson_janssen", supply_level="in_stock")
         )
@@ -168,7 +168,7 @@ def _filter_name(building: str, site: dict) -> str:
 
     # Remove vaccine types.
     name = re.sub(
-        r"""\b(j&j|johnson\s+(and|&)\s+johnson|moderna|pfizer)\b""",
+        r"""\b(j&j|janssen|johnson\s+(and|&)\s+johnson|moderna|pfizer)\b""",
         "",
         name,
         flags=re.IGNORECASE | re.VERBOSE,
@@ -190,8 +190,9 @@ def _filter_name(building: str, site: dict) -> str:
     for name in possible_names:
         name = name.strip(" -\xa0")
         name = re.sub(r"(\s+[-]|[-]\s+)", r" \1 ", name)
-        name = re.sub(r":\s+-", ": ", name)
+        name = re.sub(r"([-:/])(\s+[-:/])+", r"\1 ", name)
         name = re.sub(r"\s+", " ", name)
+        name = name.strip(" -:/")
         # Short names are probably just "Clinic" or "Vaccine".
         if len(name) > 7:
             return name

--- a/vaccine_feed_ingest/runners/il/juvare/normalize.py
+++ b/vaccine_feed_ingest/runners/il/juvare/normalize.py
@@ -88,13 +88,15 @@ def _get_building_and_address(site: dict) -> Tuple[str, Optional[schema.Address]
 
 
 def _get_contact(site: dict) -> schema.Contact:
-    indirect_url = "https://covidvaccination.dph.illinois.gov/"
+    # indirect_url = "https://covidvaccination.dph.illinois.gov/"
 
     # NOTE: This direct url bypasses the consent form used at the indirect url,
-    # so we don't actually return it.
-    # direct_url = f"https://events.juvare.com/{site['organizer']}/{site['slug']}/"
+    # but it's very easy for people to find the direct url by following links
+    # from provider websites and search results, so it should be okay to return
+    # it.
+    direct_url = f"https://events.juvare.com/{site['organizer']}/{site['slug']}/"
 
-    return [schema.Contact(contact_type="booking", website=indirect_url)]
+    return [schema.Contact(contact_type="booking", website=direct_url)]
 
 
 def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:

--- a/vaccine_feed_ingest/runners/il/juvare/normalize.py
+++ b/vaccine_feed_ingest/runners/il/juvare/normalize.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# parts adapted from ok/vaccinate_gov/normalize.py
+
+import datetime
+import json
+import pathlib
+import re
+import sys
+from typing import List
+
+from vaccine_feed_ingest.schema import schema  # noqa: E402
+
+
+def _get_source(site: dict, timestamp: str) -> schema.Source:
+    return schema.Source(
+        source="il_juvare",
+        id=site["slug"],
+        fetched_from_uri="https://covidvaccination.dph.illinois.gov/",
+        fetched_at=timestamp,
+        data=site,
+    )
+
+
+def _parse_date(date: str) -> str:
+    match = re.match(r"(\d+)/(\d+)/(\d+).*", date or "")
+    if not match:
+        return None
+    month, day, year = [int(x) for x in match.groups()]
+    return f"{year:04}-{month:02}-{day:02}"
+
+
+def _get_opening_dates(site: dict) -> schema.OpenDate:
+    return [
+        schema.OpenDate(
+            opens=_parse_date(site["dateFrom"]), closes=_parse_date(site["dateTo"])
+        )
+    ]
+
+
+def _get_access(site: dict) -> schema.Access:
+    if re.search(r"\bdrive[- ](thru|up)\b", site["name"], flags=re.IGNORECASE):
+        return schema.Access(drive=True)
+    return None
+
+
+def _get_building_and_address(site: dict) -> (str, schema.Address):
+    # NOTE: some locations are missing the ZIP code. We return None for these
+    # locations because the schema requires a ZIP code.
+
+    # The street name often runs together with the city name, like this:
+    # "3601 W 183rd St Hazel Crest IL 60429".
+    # We look for punctuation or a street type (like "St") at the end of the
+    # street name.
+
+    match = re.match(
+        r"""
+        (?P<building>[^0-9]*)        # building name
+        (?P<street>[0-9].*           # street address, must end with punctuation or street type
+          (\b(ave|avenue|blvd|boulevard|cir|circle|ct|court|dr|drive|hwy|highway|ln|lane|pkwy|parkway|st|street|way)\b\s*|[.,0-9]\s*|[\r\n])
+        )
+        (?P<city>(\b\w+[ ]*)+)       # city
+        [,]?\s+(IL|Illinois)\b[.,]?  # state
+        \s+(?P<zip>\d{5})(-\d{4})?   # zip
+        (?P<extra>.*)                # building name, instructions, county name, "united states", etc.
+        """,
+        site["location"],
+        re.DOTALL | re.IGNORECASE | re.VERBOSE,
+    )
+
+    if not match:
+        return ("", None)
+
+    address = schema.Address(
+        street1=match.group("street").strip(" ,\r\n"),
+        city=match.group("city"),
+        state="IL",
+        zip=match.group("zip"),
+    )
+    building = match.group("building") or match.group("extra")
+    if re.match(
+        r".*\b(county|united states|enter off crystal lake)\b",
+        building,
+        flags=re.IGNORECASE,
+    ):
+        building = ""
+    building = building.strip(" ,\r\n@.")
+    return (building, address)
+
+
+def _get_contact(site: dict) -> schema.Contact:
+    indirect_url = "https://covidvaccination.dph.illinois.gov/"
+
+    # NOTE: This direct url bypasses the consent form used at the indirect url,
+    # so we don't actually return it.
+    # direct_url = f"https://events.juvare.com/{site['organizer']}/{site['slug']}/"
+
+    return [schema.Contact(contact_type="booking", website=indirect_url)]
+
+
+def _get_inventory(site: dict) -> List[schema.Vaccine]:
+    name = site["name"]
+
+    inventory = []
+
+    pfizer = re.search("pfizer", name, re.IGNORECASE)
+    moderna = re.search("moderna", name, re.IGNORECASE)
+    johnson = re.search("janssen|johnson.*johnson|j&j", name, re.IGNORECASE)
+
+    if pfizer:
+        inventory.append(
+            schema.Vaccine(vaccine="pfizer_biontech", supply_level="in_stock")
+        )
+    elif moderna:
+        inventory.append(schema.Vaccine(vaccine="moderna", supply_level="in_stock"))
+    elif johnson:
+        inventory.append(
+            schema.Vaccine(vaccine="johnson_johnson_janssen", supply_level="in_stock")
+        )
+
+    if len(inventory) == 0:
+        return None
+
+    return inventory
+
+
+def _filter_name(building: str, site: dict) -> str:
+    if building:
+        # The building name from the address is almost always better than the
+        # name from the "name" field. For example, the address has "West
+        # Prairie High School" when the name field has "McDonough - (WPHS)".
+        return re.sub(r"\r?\n", " - ", building)
+
+    name = site["name"]
+    possible_names = [name]
+
+    # Remove dates from beginning of name.
+    name = re.sub(
+        r"""^(
+            [-/,& 0-9\xa0\u2013]
+            | [a-z]*day\b        # Monday, etc.
+            | th\b               # 24th, etc.
+            | \b(
+                and|to
+                |jan(uary)?|feb(ruary)?|mar(ch)?|apr(il)?|may|june?
+                |july?|aug(ust)?|sep(tember)?|oct(ober)?|nov(ember)?|dec(ember)?
+              )
+            \b)+""",
+        "",
+        name,
+        flags=re.IGNORECASE | re.VERBOSE,
+    )
+    possible_names.append(name)
+
+    # Remove dose counts ("120 doses") and numbers ("1st and 2nd doses",
+    # "dose 1").
+    name = re.sub(
+        r"""\b\d+\s+doses\b
+            |\bfor\s+those\s+that\s+received.*
+            |\b((1st|first|2nd|second|single|and|or|&)\s+)+doses?\b
+            |\bdoses?\s+(\s+|[#]|[12]|and|or|&)+\b
+            |\b(1st|first|2nd|second)\b
+            |[#][12]\b""",
+        "",
+        name,
+        flags=re.IGNORECASE | re.VERBOSE,
+    )
+    possible_names.append(name)
+
+    # Remove vaccine types.
+    name = re.sub(
+        r"""\b(j&j|johnson\s+(and|&)\s+johnson|moderna|pfizer)\b""",
+        "",
+        name,
+        flags=re.IGNORECASE | re.VERBOSE,
+    )
+    possible_names.append(name)
+
+    # Remove county names. Note that this doesn't modify things like "Vermilion
+    # County Health Department".
+    name = re.sub(
+        r"""^(([-a-z]+,?|&)\s+)+(bi)?count(y|ies)\s*[-\u2013]""",
+        "",
+        name,
+        flags=re.IGNORECASE | re.VERBOSE,
+    )
+    possible_names.append(name)
+
+    # Find the shortest name that looks reasonable.
+    possible_names.reverse()
+    for name in possible_names:
+        name = name.strip(" -\xa0")
+        name = re.sub(r"(\s+[-]|[-]\s+)", r" \1 ", name)
+        name = re.sub(r":\s+-", ": ", name)
+        name = re.sub(r"\s+", " ", name)
+        # Short names are probably just "Clinic" or "Vaccine".
+        if len(name) > 7:
+            return name
+
+    return name
+
+
+def normalize(site: dict, timestamp: str) -> str:
+    """
+    input keys:
+    - "organizer": Always "IL-IDPH".
+    - "slug": Unique ID, may be a UUID or something like "7vbvl-29-31". Used in URLs.
+    - "name": Name, often includes dates and vaccine type but no consistent format.
+    - "location": Street address, no consistent format.
+    - "dateFrom": Start time, always formatted like "4/24/2021, 9:30 AM".
+    - "dateTo": End time, may be null, otherwise always formatted like "4/24/2021, 4:30 PM".
+    - "lat": Latitude, may be null.
+    - "lon": Longitude, may be null.
+    - "search": Not interesting, just a bunch of the other fields joined together.
+    """
+    building, address = _get_building_and_address(site)
+
+    if site["lat"] and site["lon"]:
+        location = {"latitude": site["lat"], "longitude": site["lon"]}
+    else:
+        location = None
+
+    normalized = schema.NormalizedLocation(
+        id=f"il_juvare:{site['slug']}",
+        name=_filter_name(building, site),
+        address=address,
+        location=location,
+        contact=_get_contact(site),
+        opening_dates=_get_opening_dates(site),
+        availability=schema.Availability(appointments=True),
+        inventory=_get_inventory(site),
+        access=_get_access(site),
+        active=True,
+        source=_get_source(site, timestamp),
+    ).dict()
+    return normalized
+
+
+parsed_at_timestamp = datetime.datetime.utcnow().isoformat()
+
+input_dir = pathlib.Path(sys.argv[2])
+input_file = input_dir / "events.parsed.ndjson"
+output_dir = pathlib.Path(sys.argv[1])
+output_file = output_dir / "events.normalized.ndjson"
+
+with input_file.open() as parsed_lines:
+    with output_file.open("w") as fout:
+        for line in parsed_lines:
+            site = json.loads(line)
+            normalized_site = normalize(site, parsed_at_timestamp)
+            json.dump(normalized_site, fout)
+            fout.write("\n")


### PR DESCRIPTION
# Normalize juvare for IL

| Key Details |
|-|
| Resolves #205 |
State: il |
Site: juvare |

## Notes
Several things about this normalizer need discussion:
- It's possible to generate direct links to the sign-up form for each site, like this: <https://events.juvare.com/IL-IDPH/0406ec6d-e7c9-40f0-aa86-98b0d8a5acdf/>. However, these links bypass the consent form at <https://covidvaccination.dph.illinois.gov/>, so I thought it would be safer to return that site instead.
- The source only seems to list sites that have available signup times. I'm therefore returning `"supply_level":"in_stock"`, on the assumption that any site with available times will have available stock.
- The source frequently includes duplicates of the same site with different dates or different vaccine types (1st dose vs. 2nd dose). I'm returning the duplicates as-is, but let me know if I should try eliminating them. This also means that `"opening_dates"` may only be a subset of the actual opening dates of the site.

## Data sample
```json
{"id": "il_juvare:285fe792-fcd0-4ca1-9471-dd92752c84b6", "name": "IDHS - Mabley Developmental Center Vaccination POD", "address": {"street1": "1120 Washington Avenue", "street2": null, "city": "Dixon", "state": "IL", "zip": "61201"}, "location": {"latitude": 41.861388, "longitude": -89.479465}, "contact": [{"contact_type": "booking", "phone": null, "website": "https://covidvaccination.dph.illinois.gov/", "email": null, "other": null}], "languages": null, "opening_dates": [{"opens": "2021-03-30", "closes": "2021-04-30"}], "opening_hours": null, "availability": {"drop_in": null, "appointments": true}, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": null, "active": true, "source": {"source": "il_juvare", "id": "285fe792-fcd0-4ca1-9471-dd92752c84b6", "fetched_from_uri": "https://covidvaccination.dph.illinois.gov/", "fetched_at": "2021-04-27T02:54:55.455657", "published_at": null, "data": {"organizer": "IL-IDPH", "slug": "285fe792-fcd0-4ca1-9471-dd92752c84b6", "name": "03/30 to 04/30 - IDHS - Mabley Developmental Center Vaccination POD", "location": "1120 Washington Avenue Dixon, IL 61201", "dateFrom": "3/30/2021, 9:00 AM", "dateTo": "4/30/2021, 3:30 PM", "lat": 41.861388, "lon": -89.479465, "search": "03/30 to 04/30 - idhs - mabley developmental center vaccination pod 1120 washington avenue dixon, il 61201 3/30/2021, 9:00 am 4/30/2021, 3:30 pm"}}}
{"id": "il_juvare:415331f6-0a4e-423a-b797-3c3aa99bb079", "name": "IDHS - Choate Developmental Center Vaccination", "address": {"street1": "1000 N. Main", "street2": null, "city": "Anna", "state": "IL", "zip": "62906"}, "location": {"latitude": 37.459465, "longitude": -89.197838}, "contact": [{"contact_type": "booking", "phone": null, "website": "https://covidvaccination.dph.illinois.gov/", "email": null, "other": null}], "languages": null, "opening_dates": [{"opens": "2021-03-31", "closes": "2021-05-19"}], "opening_hours": null, "availability": {"drop_in": null, "appointments": true}, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": null, "active": true, "source": {"source": "il_juvare", "id": "415331f6-0a4e-423a-b797-3c3aa99bb079", "fetched_from_uri": "https://covidvaccination.dph.illinois.gov/", "fetched_at": "2021-04-27T02:54:55.455657", "published_at": null, "data": {"organizer": "IL-IDPH", "slug": "415331f6-0a4e-423a-b797-3c3aa99bb079", "name": "03/31 to 05/19 - IDHS - Choate Developmental Center Vaccination", "location": "1000 N. Main, Anna, IL 62906", "dateFrom": "3/31/2021, 10:00 AM", "dateTo": "5/19/2021, 7:00 PM", "lat": 37.459465, "lon": -89.197838, "search": "03/31 to 05/19 - idhs - choate developmental center vaccination 1000 n. main, anna, il 62906 3/31/2021, 10:00 am 5/19/2021, 7:00 pm"}}}
{"id": "il_juvare:4f10bfeb-6d6a-4a9b-9059-1e06b405743f", "name": "State Mass Vaccination Site", "address": {"street1": "3128 Voyager Ln", "street2": null, "city": "Joliet", "state": "IL", "zip": "60435"}, "location": {"latitude": 41.575844, "longitude": -88.161001}, "contact": [{"contact_type": "booking", "phone": null, "website": "https://covidvaccination.dph.illinois.gov/", "email": null, "other": null}], "languages": null, "opening_dates": [{"opens": "2021-04-01", "closes": "2021-05-30"}], "opening_hours": null, "availability": {"drop_in": null, "appointments": true}, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": null, "active": true, "source": {"source": "il_juvare", "id": "4f10bfeb-6d6a-4a9b-9059-1e06b405743f", "fetched_from_uri": "https://covidvaccination.dph.illinois.gov/", "fetched_at": "2021-04-27T02:54:55.455657", "published_at": null, "data": {"organizer": "IL-IDPH", "slug": "4f10bfeb-6d6a-4a9b-9059-1e06b405743f", "name": "04/01/2021 \u2013 Will County \u2013 State Mass Vaccination Site", "location": "3128 Voyager Ln Joliet IL 60435", "dateFrom": "4/1/2021, 10:00 AM", "dateTo": "5/30/2021, 6:00 PM", "lat": 41.575844, "lon": -88.161001, "search": "04/01/2021 \u2013 will county \u2013 state mass vaccination site 3128 voyager ln joliet il 60435 4/1/2021, 10:00 am 5/30/2021, 6:00 pm"}}}
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
