### PR TITLE
chore: validate in-bound latitude and longitude

### DIFF
--- a/vaccine_feed_ingest/stages/ingest.py
+++ b/vaccine_feed_ingest/stages/ingest.py
@@ -11,6 +11,7 @@ from vaccine_feed_ingest_schema import schema
 
 from . import outputs, site
 from .common import RUNNERS_DIR, STAGE_OUTPUT_SUFFIX, PipelineStage
+from .validation import BOUNDING_BOX
 
 logger = logging.getLogger("ingest")
 
@@ -311,7 +312,7 @@ def _validate_normalized(output_dir: pathlib.Path) -> bool:
         with filepath.open() as ndjson_file:
             for line_no, content in enumerate(ndjson_file):
                 try:
-                    schema.NormalizedLocation.parse_raw(content)
+                    normalized_location = schema.NormalizedLocation.parse_raw(content)
                 except pydantic.ValidationError as e:
                     logger.warning(
                         "Invalid source location in %s at line %d: %s\n%s",
@@ -322,4 +323,18 @@ def _validate_normalized(output_dir: pathlib.Path) -> bool:
                     )
                     return False
 
+                if normalized_location.location:
+                    if not BOUNDING_BOX.latitude.contains(
+                        normalized_location.location.latitude
+                    ) or not BOUNDING_BOX.longitude.contains(
+                        normalized_location.location.longitude
+                    ):
+                        logger.warning(
+                            "Invalid latitude or longitude in %s at line %d: %s is outside approved bounds (%s)",
+                            filepath,
+                            line_no,
+                            normalized_location.location,
+                            BOUNDING_BOX,
+                        )
+                        return False
     return True

--- a/vaccine_feed_ingest/stages/validation.py
+++ b/vaccine_feed_ingest/stages/validation.py
@@ -1,0 +1,28 @@
+"""Shared constants for validation"""
+
+from pydantic import BaseModel
+
+
+class MinMax(BaseModel):
+    minimum: float
+    maximum: float
+
+    def contains(self, x: float) -> bool:
+        return x > self.minimum and x < self.maximum
+
+
+class BoundingBox(BaseModel):
+    latitude: MinMax
+    longitude: MinMax
+
+
+BOUNDING_BOX = BoundingBox(
+    latitude=MinMax(
+        minimum=-14.549,
+        maximum=71.367,
+    ),
+    longitude=MinMax(
+        minimum=-179.779,
+        maximum=0.0,
+    ),
+)


### PR DESCRIPTION
Supplement existing validation that runs after the `normalize` step to confirm that `latitude` and `longitude` values make sense. This is primarily targeted at catching (and blocking) normalizers which flip lat/lng.

The configuration for the bounding box is a best-guess based on current config for VaccinateTheStates.com. 