### PR TITLE
Fix normalized records for vaxfinder, and use Pydantic schema

### DIFF
--- a/vaccine_feed_ingest/runners/ma/vaxfinder_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ma/vaxfinder_gov/normalize.py
@@ -4,7 +4,6 @@ import datetime
 import json
 import pathlib
 import sys
-
 from hashlib import md5
 
 # import schema
@@ -17,7 +16,8 @@ from schema import schema  # noqa: E402
 
 
 def _generate_id(unique_str: str) -> str:
-    return md5(unique_str.encode('utf-8')).hexdigest()
+    return md5(unique_str.encode("utf-8")).hexdigest()
+
 
 def normalize(site: dict, timestamp: str) -> schema.NormalizedLocation:
     # addresses are typically formatted like this: 800 Boylston Street, Boston, MA 02199

--- a/vaccine_feed_ingest/runners/ma/vaxfinder_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ma/vaxfinder_gov/normalize.py
@@ -5,8 +5,21 @@ import json
 import pathlib
 import sys
 
+from hashlib import md5
 
-def normalize(site: dict, timestamp: str) -> dict:
+# import schema
+site_dir = pathlib.Path(__file__).parent
+state_dir = site_dir.parent
+runner_dir = state_dir.parent
+root_dir = runner_dir.parent
+sys.path.append(str(root_dir))
+from schema import schema  # noqa: E402
+
+
+def _generate_id(unique_str: str) -> str:
+    return md5(unique_str.encode('utf-8')).hexdigest()
+
+def normalize(site: dict, timestamp: str) -> schema.NormalizedLocation:
     # addresses are typically formatted like this: 800 Boylston Street, Boston, MA 02199
     # sometimes, "MA" is not included, so there's a handler below for that
     address = site["address"]
@@ -36,31 +49,42 @@ def normalize(site: dict, timestamp: str) -> dict:
     # The locations we get typically are formatted like:
     # "Abington: Walmart (Brockton Ave.)". We don't need the city name twice
     name_without_city = site["name"].split(":")[1].strip()
-    normalized = {
-        "name": name_without_city,
-        address: {
-            "street1": street1,
-            "street2": street2,
-            "city": city,
-            "state": "MA",
-            "zip": zipcode,
-        },
-        "contact": [
-            {
-                "contact_type": "booking",
-                "website": "https://vaxfinder.mass.gov",
-            },
-        ],
-        "fetched_at": timestamp,
-        "source": {
-            "source": "vaxfinder",
-            "fetched_from_uri": "https://www.mass.gov/doc/covid-19-vaccine-locations-for-currently-eligible-recipients-csv/download",  # noqa: E501
-            "fetched_at": timestamp,
-            "data": site,
-        },
-    }
 
-    return normalized
+    location_id = _generate_id(name_without_city + address)
+
+    return schema.NormalizedLocation(
+        id=location_id,
+        name=name_without_city,
+        address=schema.Address(
+            street1=street1,
+            street2=street2,
+            city=city,
+            state="MA",
+            zip=zipcode,
+        ),
+        location=None,
+        contact=[
+            schema.Contact(website="https://vaxfinder.mass.gov", contact_type="booking")
+        ],
+        languages=None,
+        opening_dates=None,
+        opening_hours=None,
+        availability=None,
+        inventory=None,
+        access=None,
+        parent_organization=None,
+        links=None,
+        notes=None,
+        active=None,
+        source=schema.Source(
+            source="vaxfinder",
+            id=location_id,
+            fetched_from_uri="https://www.mass.gov/doc/covid-19-vaccine-locations-for-currently-eligible-recipients-csv/download",  # noqa: E501
+            fetched_at=timestamp,
+            published_at=None,
+            data=site,
+        ),
+    )
 
 
 output_dir = pathlib.Path(sys.argv[1])
@@ -79,5 +103,5 @@ with input_filepath.open() as fin:
 
             normalized_site = normalize(parsed_site, parsed_at_timestamp)
 
-            json.dump(normalized_site, fout)
+            json.dump(normalized_site.dict(), fout)
             fout.write("\n")


### PR DESCRIPTION
# <!-- <stage> <site> for <state> (e.g.,  Normalize ArcGIS for MD) -->

| Key Details |
|-|
| Resolves #223 |
State: ma |
Site: vaxfinder_gov |

## Notes
Pretty straightforward bug fix:

1. Use the Pydantic schema as noted in #233
2. Since there's no ID in the raw data, generate one via an md5 hash of the name & address

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```json
{"id": "ca79bf5dd35fb01154dab979d1ac103f", "name": "CVS (Centre Ave.)", "address": {"street1": "385 Centre Ave", "street2": null, "city": "Abington", "state": "MA", "zip": "02351"}, "location": null, "contact": [{"contact_type": "booking", "phone": null, "website": "https://vaxfinder.mass.gov", "email": null, "other": null}], "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": null, "active": null, "source": {"source": "vaxfinder", "id": "ca79bf5dd35fb01154dab979d1ac103f", "fetched_from_uri": "https://www.mass.gov/doc/covid-19-vaccine-locations-for-currently-eligible-recipients-csv/download", "fetched_at": "2021-04-27T18:48:55.971497", "published_at": null, "data": {"name": "Abington: CVS (Centre Ave.)", "address": "385 Centre Ave, Abington, MA 02351"}}}
{"id": "43dd70f3e1e1eea79257e052b01c938a", "name": "Stop and Shop (Centre Avenue)", "address": {"street1": "375 Centre Avenue (Route 123)", "street2": null, "city": "Abington", "state": "MA", "zip": "02351"}, "location": null, "contact": [{"contact_type": "booking", "phone": null, "website": "https://vaxfinder.mass.gov", "email": null, "other": null}], "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": null, "active": null, "source": {"source": "vaxfinder", "id": "43dd70f3e1e1eea79257e052b01c938a", "fetched_from_uri": "https://www.mass.gov/doc/covid-19-vaccine-locations-for-currently-eligible-recipients-csv/download", "fetched_at": "2021-04-27T18:48:55.971497", "published_at": null, "data": {"name": "Abington: Stop and Shop (Centre Avenue)", "address": "375 Centre Avenue (Route 123), Abington, MA 02351"}}}
{"id": "13d26fd16bb609c1c55056995c5d1336", "name": "Walmart (Brockton Ave.)", "address": {"street1": "777 Brockton Ave", "street2": null, "city": "Abington", "state": "MA", "zip": "02351"}, "location": null, "contact": [{"contact_type": "booking", "phone": null, "website": "https://vaxfinder.mass.gov", "email": null, "other": null}], "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": null, "active": null, "source": {"source": "vaxfinder", "id": "13d26fd16bb609c1c55056995c5d1336", "fetched_from_uri": "https://www.mass.gov/doc/covid-19-vaccine-locations-for-currently-eligible-recipients-csv/download", "fetched_at": "2021-04-27T18:48:55.971497", "published_at": null, "data": {"name": "Abington: Walmart (Brockton Ave.)", "address": "777 Brockton Ave, Abington, MA 02351"}}}
{"id": "acb55ed282c7cf55bb2904a424b02df2", "name": "Acton Pharmacy", "address": {"street1": "563 Massachusetts Ave", "street2": null, "city": "Acton", "state": "MA", "zip": "01720"}, "location": null, "contact": [{"contact_type": "booking", "phone": null, "website": "https://vaxfinder.mass.gov", "email": null, "other": null}], "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": null, "active": null, "source": {"source": "vaxfinder", "id": "acb55ed282c7cf55bb2904a424b02df2", "fetched_from_uri": "https://www.mass.gov/doc/covid-19-vaccine-locations-for-currently-eligible-recipients-csv/download", "fetched_at": "2021-04-27T18:48:55.971497", "published_at": null, "data": {"name": "Acton: Acton Pharmacy", "address": "563 Massachusetts Ave, Acton, MA 01720"}}}
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest normalize ma/vaxfinder_gov`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
