### PR TITLE
fix(vaccinespotter_org): valid addresses and lat/lngs

### DIFF
--- a/vaccine_feed_ingest/runners/ct/covidvaccinefinder_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ct/covidvaccinefinder_gov/normalize.py
@@ -20,7 +20,7 @@ logger = logging.getLogger("ct/covidvaccinefinder_gov")
 def _in_bounds(lat_lng: schema.LatLng) -> bool:
     if BOUNDING_BOX.latitude.contains(
         lat_lng.latitude
-    ) or BOUNDING_BOX.longitude.contains(lat_lng.longitude):
+    ) and BOUNDING_BOX.longitude.contains(lat_lng.longitude):
         return True
     return False
 


### PR DESCRIPTION
* Fix a boolean logic bug introduced in #238. This ultimately doesn't impact the output (because under the existing logic flipped lat/lngs still failed the method), but we should fix it!
* Update `vaccinespotter_org` to begin to use the schema in order to enforce:
  * valid addresses
  * valid lat/lngs 

We should finish converting `vaccinespotter_org` to use the schema (#233), but validation errors on `Address` and `Location` were preventing promotion of this data, so I did this partial fix.