### PR TITLE
Ca metrolink normalize

### DIFF
--- a/vaccine_feed_ingest/runners/ca/metrolink/normalize.py
+++ b/vaccine_feed_ingest/runners/ca/metrolink/normalize.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+import datetime
+import json
+import logging
+import pathlib
+import sys
+
+from vaccine_feed_ingest_schema import schema  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
+    datefmt="%m/%d/%Y %H:%M:%S",
+)
+logger = logging.getLogger("ca/metrolink/normalize.py")
+
+_source_name = "ca_metrolink"
+
+
+def _get_id(site: dict) -> str:
+    name = _get_name(site)
+    city = _get_city(site)
+
+    id = f"{name}_{city}".lower()
+    id = id.replace(" ", "_").replace("\u2019", "_").replace("#", "_")
+    id = id.replace(".", "_").replace(",", "_").replace("'", "_")
+    id = id.replace("(", "_").replace(")", "_").replace("/", "_")
+
+    return id
+
+
+def _get_name(site: dict) -> str:
+    return site["name"]
+
+
+def _get_city(site: dict) -> str:
+    return site["city"]
+
+
+def _get_address(site: dict):
+    return schema.Address(
+        street1=site["address"],
+        city=_get_city(site),
+        zip=None,
+        state="CA",
+    )
+
+
+def _get_notes(site: dict):
+    ret = []
+    metrolink_station = site["metrolink_station"]
+    metrolink_line = site["metrolink_line"]
+    ret.append(
+        f"ca_metrolink_directions: Near the {metrolink_station} station on the {metrolink_line} line."
+    )
+    return ret
+
+
+def _get_source(site: dict, timestamp: str) -> schema.Source:
+    return schema.Source(
+        data=site,
+        fetched_at=timestamp,
+        fetched_from_uri="https://register.metrolinktrains.com/web-assets/vax-sites/index.php",
+        id=_get_id(site),
+        source=_source_name,
+    )
+
+
+def normalize(site: dict, timestamp: str) -> str:
+    normalized = schema.NormalizedLocation(
+        id=(_source_name + ":" + _get_id(site)),
+        name=_get_name(site),
+        address=_get_address(site),
+        notes=_get_notes(site),
+        source=_get_source(site, timestamp),
+    ).dict()
+    return normalized
+
+
+parsed_at_timestamp = datetime.datetime.utcnow().isoformat()
+
+input_dir = pathlib.Path(sys.argv[2])
+input_file = input_dir / "metrolink.html.parsed.ndjson"
+output_dir = pathlib.Path(sys.argv[1])
+output_file = output_dir / "metrolink.html.normalized.ndjson"
+
+with input_file.open() as parsed_lines:
+    with output_file.open("w") as fout:
+        for line in parsed_lines:
+            site_blob = json.loads(line)
+
+            normalized_site = normalize(site_blob, parsed_at_timestamp)
+
+            json.dump(normalized_site, fout)
+            fout.write("\n")


### PR DESCRIPTION
# normalize metrolink for ca

| Key Details |
|-|
| Resolves #179 |
State: ca |
Site: metrolink |

## Notes
* very minimal data at this site, so we do the best we can.

## Data sample
```json
{"id": "ca:metrolink:Pomona Fairplex (Gate 15):Pomona", "name": "Pomona Fairplex (Gate 15)", "address": {"street1": "2352 Arrow Hwy.", "street2": null, "city": "Pomona", "state": "CA", "zip": "0"}, "location": null, "contact": null, "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": ["metrolink_line__ca_specific:San Bernardino", "metrolink_station__ca_specific:Pomona - North"], "active": null, "source": {"source": "ca:metrolink", "id": "Pomona Fairplex (Gate 15):Pomona", "fetched_from_uri": "https://register.metrolinktrains.com/web-assets/vax-sites/index.php", "fetched_at": "2021-04-27T22:51:39.981992", "published_at": null, "data": {"name": "Pomona Fairplex (Gate 15)", "address": "2352 Arrow Hwy.", "city": "Pomona", "metrolink_line": "San Bernardino", "metrolink_station": "Pomona - North"}}}
{"id": "ca:metrolink:Cal State Northridge:Northridge", "name": "Cal State Northridge", "address": {"street1": "18343 Plummer Street", "street2": null, "city": "Northridge", "state": "CA", "zip": "0"}, "location": null, "contact": null, "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": ["metrolink_line__ca_specific:Ventura County", "metrolink_station__ca_specific:Northridge"], "active": null, "source": {"source": "ca:metrolink", "id": "Cal State Northridge:Northridge", "fetched_from_uri": "https://register.metrolinktrains.com/web-assets/vax-sites/index.php", "fetched_at": "2021-04-27T22:51:39.981992", "published_at": null, "data": {"name": "Cal State Northridge", "address": "18343 Plummer Street", "city": "Northridge", "metrolink_line": "Ventura County", "metrolink_station": "Northridge"}}}
{"id": "ca:metrolink:El Sereno Recreation Center:Los Angeles", "name": "El Sereno Recreation Center", "address": {"street1": "4721 Klamath St.", "street2": null, "city": "Los Angeles", "state": "CA", "zip": "0"}, "location": null, "contact": null, "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": ["metrolink_line__ca_specific:San Bernardino", "metrolink_station__ca_specific:Cal State L.A."], "active": null, "source": {"source": "ca:metrolink", "id": "El Sereno Recreation Center:Los Angeles", "fetched_from_uri": "https://register.metrolinktrains.com/web-assets/vax-sites/index.php", "fetched_at": "2021-04-27T22:51:39.981992", "published_at": null, "data": {"name": "El Sereno Recreation Center", "address": "4721 Klamath St.", "city": "Los Angeles", "metrolink_line": "San Bernardino", "metrolink_station": "Cal State L.A."}}}
{"id": "ca:metrolink:St. John's Well Child and Family-Lincoln:Los Angeles", "name": "St. John's Well Child and Family-Lincoln", "address": {"street1": "2515 Alta St.", "street2": null, "city": "Los Angeles", "state": "CA", "zip": "0"}, "location": null, "contact": null, "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": ["metrolink_line__ca_specific:Union Station", "metrolink_station__ca_specific:Union Station"], "active": null, "source": {"source": "ca:metrolink", "id": "St. John's Well Child and Family-Lincoln:Los Angeles", "fetched_from_uri": "https://register.metrolinktrains.com/web-assets/vax-sites/index.php", "fetched_at": "2021-04-27T22:51:39.981992", "published_at": null, "data": {"name": "St. John's Well Child and Family-Lincoln", "address": "2515 Alta St.", "city": "Los Angeles", "metrolink_line": "Union Station", "metrolink_station": "Union Station"}}}
{"id": "ca:metrolink:Henry Mayo Newhall Hospital:Valencia", "name": "Henry Mayo Newhall Hospital", "address": {"street1": "23845 McBean Parkway", "street2": null, "city": "Valencia", "state": "CA", "zip": "0"}, "location": null, "contact": null, "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": ["metrolink_line__ca_specific:Antelope Valley", "metrolink_station__ca_specific:Newhall"], "active": null, "source": {"source": "ca:metrolink", "id": "Henry Mayo Newhall Hospital:Valencia", "fetched_from_uri": "https://register.metrolinktrains.com/web-assets/vax-sites/index.php", "fetched_at": "2021-04-27T22:51:39.981992", "published_at": null, "data": {"name": "Henry Mayo Newhall Hospital", "address": "23845 McBean Parkway", "city": "Valencia", "metrolink_line": "Antelope Valley", "metrolink_station": "Newhall"}}}
{"id": "ca:metrolink:East Valley Community Health Center-Pomona:Pomona", "name": "East Valley Community Health Center-Pomona", "address": {"street1": "1555 S. Garey Ave.", "street2": null, "city": "Pomona", "state": "CA", "zip": "0"}, "location": null, "contact": null, "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": ["metrolink_line__ca_specific:Riverside", "metrolink_station__ca_specific:Pomona - Downtown"], "active": null, "source": {"source": "ca:metrolink", "id": "East Valley Community Health Center-Pomona:Pomona", "fetched_from_uri": "https://register.metrolinktrains.com/web-assets/vax-sites/index.php", "fetched_at": "2021-04-27T22:51:39.981992", "published_at": null, "data": {"name": "East Valley Community Health Center-Pomona", "address": "1555 S. Garey Ave.", "city": "Pomona", "metrolink_line": "Riverside", "metrolink_station": "Pomona - Downtown"}}}
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest ca/metrolink`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
