### PR TITLE
ci: add tox to lint job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,8 +60,22 @@ jobs:
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         working-directory: vaccine-feed-ingest
 
+      - name: load .tox from cache
+        id: cached-tox-dependencies
+        uses: actions/cache@v2
+        with:
+          path: vaccine-feed-ingest/.tox
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
       - run: poetry run tox
         working-directory: vaccine-feed-ingest
+
+      - name: clean up .tox
+        working-directory: vaccine-feed-ingest
+        run: |
+          rm -f .tox/log/*
+          rm -f .tox/test/log/*
+          rm -f .tox/lint/log/*
 
 
   repo-linter:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 ---
-name: Lint
+name: Test & Lint
 on:
   push:
     branches:
@@ -18,6 +18,51 @@ jobs:
         with:
           workflows: '[".github/workflows/*.yml"]'
 
+
+  tox:
+    name: Python Lint & Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: apt-get dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libbz2-dev liblzma-dev libreadline-dev libsqlite3-dev
+
+      - uses: actions/checkout@v2
+        with:
+          repository: CAVaccineInventory/vaccine-feed-ingest
+          path: ./vaccine-feed-ingest/
+          submodules: true
+
+      - name: get python version
+        working-directory: vaccine-feed-ingest
+        run: |
+          python_version=$(cat .python-version)
+          echo "python_version=${python_version}" >> $GITHUB_ENV
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.python_version }}
+
+      - name: setup from README.md
+        run: |
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+
+      - name: load poetry install from cache
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: vaccine-feed-ingest/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      - run: poetry install
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        working-directory: vaccine-feed-ingest
+
+      - run: poetry run tox
+
+
   repo-linter:
     name: SuperLinter
     runs-on: ubuntu-latest
@@ -28,10 +73,20 @@ jobs:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
 
-      - name: Lint Code Base
+      - name: Non-Python Lint
         uses: github/super-linter@v3
         env:
+          # Only validate files modified in the PR/commit
           VALIDATE_ALL_CODEBASE: false
+          # The codebase has a lot of copy-pasted code by design
           VALIDATE_JSCPD: false
+          # We lint python in the tox job
+          VALIDATE_PYTHON: false
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_FLAKE8: false
+          VALIDATE_PYTHON_ISORT: false
+          VALIDATE_PYTHON_MYPY: false
+          VALIDATE_PYTHON_PYLINT: false
+          # General config
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,7 @@ jobs:
           path: vaccine-feed-ingest/.venv
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
-      - run: poetry install
+      - run: poetry install --dev-only
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         working-directory: vaccine-feed-ingest
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,6 +61,7 @@ jobs:
         working-directory: vaccine-feed-ingest
 
       - run: poetry run tox
+        working-directory: vaccine-feed-ingest
 
 
   repo-linter:


### PR DESCRIPTION
Run `poetry run tox` on PR. This will:
* Run `pytest` and enforce that any written tests pass.
* Run python related linters with the same config as they use locally. We do this (rather than using SuperLinter) to work around an ongoing issue where SuperLinter appears to be using a different `isort` configuration than it should be.

Because python linters are run via `tox`, disable them in SuperLinter.

Note: `tox` is slow on first-run, and in CI it will always be first-run. Future work may include adding appropriate cacheing for the dependencies brought in by tox (though this will weaken tox's value slightly, the speedup may be needed).

⚠️ In order to not break open PRs which do not include this updated workflow, we will _not_ require the `Python Lint & Test` check for several days. In the intervening time, maintainers should be careful to check that all three PR checks are ✅ before approving a PR.
