### PR TITLE
fix: poetry install --extras lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,7 @@ jobs:
           path: vaccine-feed-ingest/.venv
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
-      - run: poetry install --dev-only
+      - run: poetry install --extras lint
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         working-directory: vaccine-feed-ingest
 


### PR DESCRIPTION
Update `poetry install` in CI to go from `--dev-only` to `--extras lint`. This significantly increases the packages installed, but will work around a current issue where the `--dev-only` flag is not found.

Given our cacheing strategy, we will _rarely_ install all packages, so this is an acceptable fix to leave in place for a while.