### PR TITLE
chore(deps): bump vaccine_feed_ingest_schema to v0.2.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1829,7 +1829,7 @@ jellyfish = "0.6.1"
 
 [[package]]
 name = "vaccine-feed-ingest-schema"
-version = "0.1"
+version = "0.2.1"
 description = "Normalized data schema for the output of the vaccine-feed-ingest pipeline."
 category = "main"
 optional = false
@@ -1934,7 +1934,7 @@ test = ["pytest", "pytest-runner"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "e606a9984e46a27e6b46ccca824a1c61bbf77ba27d372bea2091ab66e2026951"
+content-hash = "a2f13c24531ea1a29fb062f59340b55a5a2d786b631fd79e7dcb4f65143462ae"
 
 [metadata.files]
 aiohttp = [
@@ -3170,8 +3170,8 @@ us = [
     {file = "us-2.0.2.tar.gz", hash = "sha256:cb11ad0d43deff3a1c3690c74f0c731cff5b862c73339df2edd91133e1496fbc"},
 ]
 vaccine-feed-ingest-schema = [
-    {file = "vaccine-feed-ingest-schema-0.1.tar.gz", hash = "sha256:f84963aac8b1a72da1d8f5d2c834251a78ad3de116110f76982442eb5b8f4758"},
-    {file = "vaccine_feed_ingest_schema-0.1-py3-none-any.whl", hash = "sha256:b666618ee144ce85324bed756d768f6671f5dc792f9b84b4d1690dcc372bbbaf"},
+    {file = "vaccine-feed-ingest-schema-0.2.1.tar.gz", hash = "sha256:5a7f31d13acdc36d9ebcd8076d71e7ef82375b23dbc0065832fe91453254d851"},
+    {file = "vaccine_feed_ingest_schema-0.2.1-py3-none-any.whl", hash = "sha256:157799ecc1ac10aac2b4ce825fffd761096726af98d8059f25f31122765c6f7a"},
 ]
 virtualenv = [
     {file = "virtualenv-20.4.4-py2.py3-none-any.whl", hash = "sha256:a935126db63128861987a7d5d30e23e8ec045a73840eeccb467c148514e29535"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ pandas = "^1.2.4"
 openpyxl = "^3.0.7"
 pytz = "^2021.1"
 beautifulsoup4 = "^4.9.3"
-vaccine-feed-ingest-schema = "^0.1"
+vaccine-feed-ingest-schema = "^0.2.1"
 aiohttp = "^3.7.4"
 
 [tool.poetry.dev-dependencies]

--- a/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
@@ -9,7 +9,7 @@ import re
 import sys
 from typing import List, Optional
 
-from vaccine_feed_ingest_schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import location as schema
 
 # Configure logger
 logging.basicConfig(

--- a/vaccine_feed_ingest/runners/az/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/az/arcgis/normalize.py
@@ -10,7 +10,7 @@ import sys
 from datetime import datetime
 from typing import List, Optional, Tuple
 
-from vaccine_feed_ingest_schema import schema
+from vaccine_feed_ingest_schema import location as schema
 
 from vaccine_feed_ingest.utils.validation import BOUNDING_BOX
 

--- a/vaccine_feed_ingest/runners/ca/sf_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ca/sf_gov/normalize.py
@@ -22,7 +22,7 @@ def normalize(site: dict, timestamp: str) -> dict:
     normalized = {
         "id": f"sf_gov:{site['id']}",
         "name": site["name"],
-        address: {
+        "address": {
             "street1": street1,
             "street2": street2,
             "city": site["location"]["city"],

--- a/vaccine_feed_ingest/runners/ca/sf_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ca/sf_gov/normalize.py
@@ -57,8 +57,6 @@ def normalize(site: dict, timestamp: str) -> dict:
                 "id": site["id"],
             },
         ],
-        "fetched_at": timestamp,
-        "published_at": site["appointments"]["last_updated"],
         "active": site["active"],
         "source": {
             "source": "sf_gov",

--- a/vaccine_feed_ingest/runners/ct/covidvaccinefinder_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ct/covidvaccinefinder_gov/normalize.py
@@ -97,8 +97,6 @@ def normalize(site: dict, timestamp: str) -> dict:
         "parent_organization": {
             "name": site["networks"][0]["name"],
         },
-        "fetched_at": timestamp,
-        "published_at": site["lastModified"],
         "source": {
             "source": "ct",
             "id": site["_id"],

--- a/vaccine_feed_ingest/runners/ct/covidvaccinefinder_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ct/covidvaccinefinder_gov/normalize.py
@@ -9,7 +9,7 @@ import sys
 from typing import Optional
 
 import pydantic
-from vaccine_feed_ingest_schema import schema
+from vaccine_feed_ingest_schema import location as schema
 
 from vaccine_feed_ingest.utils.normalize import provider_id_from_name
 from vaccine_feed_ingest.utils.validation import BOUNDING_BOX

--- a/vaccine_feed_ingest/runners/in/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/in/arcgis/normalize.py
@@ -9,7 +9,7 @@ import re
 import sys
 from typing import List, Optional
 
-from vaccine_feed_ingest_schema import schema
+from vaccine_feed_ingest_schema import location as schema
 
 # Configure logger
 logging.basicConfig(

--- a/vaccine_feed_ingest/runners/ky/govstatus/normalize.py
+++ b/vaccine_feed_ingest/runners/ky/govstatus/normalize.py
@@ -7,7 +7,7 @@ import pathlib
 import sys
 from typing import Optional
 
-from vaccine_feed_ingest_schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import location as schema
 
 # Configure logger
 logging.basicConfig(

--- a/vaccine_feed_ingest/runners/ma/vaxfinder_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ma/vaxfinder_gov/normalize.py
@@ -6,13 +6,7 @@ import pathlib
 import sys
 from hashlib import md5
 
-# import schema
-site_dir = pathlib.Path(__file__).parent
-state_dir = site_dir.parent
-runner_dir = state_dir.parent
-root_dir = runner_dir.parent
-sys.path.append(str(root_dir))
-from schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import location as schema
 
 
 def _generate_id(unique_str: str) -> str:

--- a/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
@@ -8,7 +8,7 @@ import re
 import sys
 from typing import List, Optional
 
-from vaccine_feed_ingest.schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import location as schema
 
 CITY_RE = re.compile(r"^([\w ]+), NY$")
 # the providerName field smells like it's being parsed from someplace else,

--- a/vaccine_feed_ingest/runners/mo/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/mo/arcgis/normalize.py
@@ -9,7 +9,7 @@ import re
 import sys
 from typing import List, Optional
 
-from vaccine_feed_ingest_schema import schema
+from vaccine_feed_ingest_schema import location as schema
 
 # Configure logger
 logging.basicConfig(

--- a/vaccine_feed_ingest/runners/nc/myspot_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/nc/myspot_gov/normalize.py
@@ -6,7 +6,7 @@ import logging
 import pathlib
 import sys
 
-from vaccine_feed_ingest.schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import location as schema
 
 logger = logging.getLogger(__name__)
 

--- a/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
+++ b/vaccine_feed_ingest/runners/nv/immunizenevada_org/normalize.py
@@ -7,7 +7,8 @@ import re
 import sys
 from typing import List, Optional
 
-from vaccine_feed_ingest.schema import schema
+from vaccine_feed_ingest_schema import location as schema
+
 from vaccine_feed_ingest.utils.normalize import provider_id_from_name
 
 

--- a/vaccine_feed_ingest/runners/ny/am_i_eligible_covid19vaccine_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ny/am_i_eligible_covid19vaccine_gov/normalize.py
@@ -8,7 +8,7 @@ import re
 import sys
 from typing import List, Optional
 
-from vaccine_feed_ingest.schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import location as schema
 
 CITY_RE = re.compile(r"^([\w ]+), NY$")
 # the providerName field smells like it's being parsed from someplace else,

--- a/vaccine_feed_ingest/runners/ny/am_i_eligible_covid19vaccine_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ny/am_i_eligible_covid19vaccine_gov/normalize.py
@@ -67,8 +67,6 @@ def normalize(site_blob: dict, timestamp: str) -> str:
                 authority="am_i_eligible_covid19vaccine_gov", id=site_blob["providerId"]
             ),
         ],
-        fetched_at=timestamp,
-        published_at=site_blob["lastUpdated"],
         source=_get_source(site_blob, timestamp),
     ).dict()
     normalized["address"] = {"city": city, "state": "NY"}

--- a/vaccine_feed_ingest/runners/ok/vaccinate_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ok/vaccinate_gov/normalize.py
@@ -8,7 +8,7 @@ import re
 import sys
 from typing import List
 
-from vaccine_feed_ingest.schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import location as schema
 
 
 def _get_source(site: dict, timestamp: str) -> schema.Source:

--- a/vaccine_feed_ingest/runners/pa/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/pa/arcgis/normalize.py
@@ -9,7 +9,7 @@ import re
 import sys
 from typing import List, Optional
 
-from vaccine_feed_ingest_schema import schema
+from vaccine_feed_ingest_schema import location as schema
 
 # Configure logger
 logging.basicConfig(

--- a/vaccine_feed_ingest/runners/ri/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ri/arcgis/normalize.py
@@ -9,7 +9,7 @@ import re
 import sys
 from typing import List, Optional
 
-from vaccine_feed_ingest_schema import schema
+from vaccine_feed_ingest_schema import location as schema
 
 # Configure logger
 logging.basicConfig(

--- a/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
@@ -9,7 +9,7 @@ import re
 import sys
 from typing import List, Optional
 
-from vaccine_feed_ingest_schema import schema
+from vaccine_feed_ingest_schema import location as schema
 
 # Configure logger
 logging.basicConfig(

--- a/vaccine_feed_ingest/runners/us/vaccinespotter_org/normalize.py
+++ b/vaccine_feed_ingest/runners/us/vaccinespotter_org/normalize.py
@@ -100,10 +100,6 @@ def normalize(site_blob: dict, timestamp: str) -> dict:
                 "id": site["id"],
             },
         ],
-        "fetched_at": timestamp,
-        "published_at": site[
-            "appointments_last_fetched"  # we could also use `appointments_last_modified`
-        ],
         "active": None,
         "source": {
             "source": "vaccinespotter_org",

--- a/vaccine_feed_ingest/runners/us/vaccinespotter_org/normalize.py
+++ b/vaccine_feed_ingest/runners/us/vaccinespotter_org/normalize.py
@@ -9,7 +9,7 @@ import sys
 from typing import Optional
 
 import pydantic
-from vaccine_feed_ingest_schema import schema
+from vaccine_feed_ingest_schema import location as schema
 
 from vaccine_feed_ingest.utils.normalize import provider_id_from_name
 from vaccine_feed_ingest.utils.validation import BOUNDING_BOX

--- a/vaccine_feed_ingest/runners/wa/prepmod/normalize.py
+++ b/vaccine_feed_ingest/runners/wa/prepmod/normalize.py
@@ -8,7 +8,7 @@ import re
 import sys
 from typing import List
 
-from vaccine_feed_ingest.schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import location as schema
 
 
 def _get_source(site: dict, timestamp: str) -> schema.Source:

--- a/vaccine_feed_ingest/schema/schema.py
+++ b/vaccine_feed_ingest/schema/schema.py
@@ -10,7 +10,9 @@ DEPRECATION NOTICE
 vaccine_feed_ingest/schema/schema.py is DEPRECATED. Instead of using this file,
 import the published package using the line:
 
-from vaccine_feed_ingest_schema import schema
+from vaccine_feed_ingest_schema import location
+~or~
+from vaccine_feed_ingest_schema import load
 
 This file is maintained in the source so that currently open PRs will not break.
 It will be removed from source by 2021-05-01, potentially earlier.

--- a/vaccine_feed_ingest/stages/ingest.py
+++ b/vaccine_feed_ingest/stages/ingest.py
@@ -7,7 +7,7 @@ import subprocess
 import tempfile
 
 import pydantic
-from vaccine_feed_ingest_schema import schema
+from vaccine_feed_ingest_schema import location
 
 from ..utils.validation import BOUNDING_BOX
 from . import outputs, site
@@ -312,7 +312,7 @@ def _validate_normalized(output_dir: pathlib.Path) -> bool:
         with filepath.open() as ndjson_file:
             for line_no, content in enumerate(ndjson_file):
                 try:
-                    normalized_location = schema.NormalizedLocation.parse_raw(content)
+                    normalized_location = location.NormalizedLocation.parse_raw(content)
                 except pydantic.ValidationError as e:
                     logger.warning(
                         "Invalid source location in %s at line %d: %s\n%s",

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -8,7 +8,7 @@ import rtree
 import shapely.geometry
 import urllib3
 import us
-from vaccine_feed_ingest_schema import load
+from vaccine_feed_ingest_schema import load, location
 
 from .. import vial
 from ..utils.match import canonicalize_address, get_full_address
@@ -58,7 +58,7 @@ def run_load_to_vial(
         with filepath.open() as src_file:
             for line in src_file:
                 try:
-                    normalized_location = load.NormalizedLocation.parse_raw(line)
+                    normalized_location = location.NormalizedLocation.parse_raw(line)
                 except pydantic.ValidationError as e:
                     logger.warning(
                         "Skipping source location because it is invalid: %s\n%s",
@@ -116,7 +116,7 @@ def run_load_to_vial(
 
 
 def _find_candidates(
-    source: load.NormalizedLocation,
+    source: location.NormalizedLocation,
     existing: rtree.index.Index,
 ) -> Iterator[dict]:
     """Return a slice of existing locations"""
@@ -130,7 +130,7 @@ def _find_candidates(
     yield from existing.intersection(search_bounds, objects="raw")
 
 
-def _is_different(source: load.NormalizedLocation, candidate: dict) -> bool:
+def _is_different(source: location.NormalizedLocation, candidate: dict) -> bool:
     """Return True if candidate is so different it couldn't be a match"""
     candidate_props = candidate.get("properties", {})
 
@@ -161,7 +161,7 @@ def _is_different(source: load.NormalizedLocation, candidate: dict) -> bool:
     return False
 
 
-def _is_match(source: load.NormalizedLocation, candidate: dict) -> bool:
+def _is_match(source: location.NormalizedLocation, candidate: dict) -> bool:
     """Return True if candidate is so similar it must be a match"""
     source_links = (
         set("{}:{}".format(link.authority, link.id) for link in source.links)
@@ -190,7 +190,7 @@ def _is_match(source: load.NormalizedLocation, candidate: dict) -> bool:
 
 
 def _match_source_to_existing_locations(
-    source: load.NormalizedLocation,
+    source: location.NormalizedLocation,
     existing: rtree.index.Index,
     enable_match: bool = True,
     enable_create: bool = False,
@@ -237,7 +237,7 @@ def _match_source_to_existing_locations(
 
 
 def _create_import_location(
-    normalized_record: load.NormalizedLocation,
+    normalized_record: location.NormalizedLocation,
     match_action: Optional[load.ImportMatchAction] = None,
 ) -> load.ImportSourceLocation:
     """Transform normalized record into import record"""

--- a/vaccine_feed_ingest/utils/match.py
+++ b/vaccine_feed_ingest/utils/match.py
@@ -1,10 +1,10 @@
 import re
 from typing import Optional
 
-from vaccine_feed_ingest_schema import schema
+from vaccine_feed_ingest_schema import location
 
 
-def get_full_address(address: Optional[schema.Address]) -> str:
+def get_full_address(address: Optional[location.Address]) -> str:
     if address is None:
         return ""
     if address.street2:

--- a/vaccine_feed_ingest/vial.py
+++ b/vaccine_feed_ingest/vial.py
@@ -10,7 +10,7 @@ import geojson
 import rtree
 import shapely.geometry
 import urllib3
-from vaccine_feed_ingest_schema import schema
+from vaccine_feed_ingest_schema import load
 
 from .utils import misc
 
@@ -67,7 +67,7 @@ def start_import_run(vial_http: urllib3.connectionpool.ConnectionPool) -> str:
 def import_source_locations(
     vial_http: urllib3.connectionpool.ConnectionPool,
     import_run_id: str,
-    import_locations: Iterable[schema.ImportSourceLocation],
+    import_locations: Iterable[load.ImportSourceLocation],
 ) -> urllib3.response.HTTPResponse:
     """Import source locations"""
     for import_locations_batch in misc.batch(import_locations, 1_000):


### PR DESCRIPTION
Update `vaccine_feed_ingest_schema` to `v0.2.1` ([release notes](https://github.com/CAVaccineInventory/vaccine-feed-ingest-schema/releases/tag/0.2.1)).

After the update, migrate all users of the existing `schema` shared import to import either `load` or `location` (per the release notes).

Finally, migrate additional users of the deprecated in-source `schema` to the published one.