### PR TITLE
Change arcgis source to match arcgis ids

### DIFF
--- a/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
@@ -140,7 +140,7 @@ def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLoc
         notes=_get_notes(site),
         active=None,
         source=schema.Source(
-            source="arcgis",
+            source="ak:arcgis",
             id=site["attributes"]["globalid"],
             fetched_from_uri="https://services1.arcgis.com/WzFsmainVTuD5KML/ArcGIS/rest/services/COVID19_Vaccine_Site_Survey_API/FeatureServer/0",  # noqa: E501
             fetched_at=timestamp,

--- a/vaccine_feed_ingest/runners/az/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/az/arcgis/normalize.py
@@ -267,7 +267,7 @@ def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLoc
         else None,
         active=None,
         source=schema.Source(
-            source="arcgis",
+            source="az:arcgis",
             id=site["attributes"]["globalid"],
             fetched_from_uri="https://adhsgis.maps.arcgis.com/apps/opsdashboard/index.html#/5d636af4d5134a819833b1a3b906e1b6",  # noqa: E501
             fetched_at=timestamp,

--- a/vaccine_feed_ingest/runners/in/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/in/arcgis/normalize.py
@@ -144,7 +144,7 @@ def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLoc
         notes=_get_notes(site),
         active=None,
         source=schema.Source(
-            source="arcgis",
+            source="in:arcgis",
             id=site["attributes"]["GlobalID"],
             fetched_from_uri="https://experience.arcgis.com/experience/24159814f1dd4f69b6c22e7e87bca65b",  # noqa: E501
             fetched_at=timestamp,

--- a/vaccine_feed_ingest/runners/mo/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/mo/arcgis/normalize.py
@@ -86,7 +86,7 @@ def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLoc
         notes=None,
         active=None,
         source=schema.Source(
-            source="arcgis",
+            source="mo:arcgis",
             id=site["attributes"]["GlobalID"],
             fetched_from_uri="https://www.arcgis.com/apps/webappviewer/index.html?id=ab04156a03584e31a14ae2eb36110c20",  # noqa: E501
             fetched_at=timestamp,

--- a/vaccine_feed_ingest/runners/pa/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/pa/arcgis/normalize.py
@@ -84,7 +84,7 @@ def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLoc
         notes=None,
         active=None,
         source=schema.Source(
-            source="arcgis",
+            source="pa:arcgis",
             id=site["attributes"]["Clinic_ID"],
             fetched_from_uri="https://padoh.maps.arcgis.com/apps/webappviewer/index.html?id=e6f78224c6fe4313a1f70b56f553c357",  # noqa: E501
             fetched_at=timestamp,

--- a/vaccine_feed_ingest/runners/ri/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ri/arcgis/normalize.py
@@ -119,7 +119,7 @@ def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLoc
         notes=_get_notes(site),
         active=None,
         source=schema.Source(
-            source="arcgis",
+            source="ri:arcgis",
             id=site["attributes"]["OBJECTID"],
             fetched_from_uri="https://rihealth.maps.arcgis.com/apps/instant/nearby/index.html?appid=a25f35833533498bac3f724f92a84b4e",  # noqa: E501
             fetched_at=timestamp,

--- a/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
@@ -156,7 +156,7 @@ def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLoc
         notes=None,
         active=_get_activated(site),
         source=schema.Source(
-            source="arcgis",
+            source="sc:arcgis",
             id=site["attributes"]["GlobalID"],
             fetched_from_uri="https://opendata.arcgis.com/datasets/bbd8924909264baaa1a5a1564b393063_0.geojson",  # noqa: E501
             fetched_at=timestamp,


### PR DESCRIPTION
Source IDs had a prefix of `{state}:arcgis` so the source should match that.