### PR TITLE
add ca/los_angeles_gov/fetch.sh

### DIFF
--- a/vaccine_feed_ingest/runners/ca/los_angeles_gov/fetch.sh
+++ b/vaccine_feed_ingest/runners/ca/los_angeles_gov/fetch.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+output_dir=""
+
+if [ -n "${1}" ]; then
+    output_dir="${1}"
+else
+    echo "Must pass an output_dir as first argument"
+fi
+
+(cd "$output_dir" && curl --silent "http://publichealth.lacounty.gov/acd/ncorona2019/js/pod-data.js" -o 'los_angeles.js')


### PR DESCRIPTION
# fetch los_angeles_gov for ca

| Key Details |
|-|
| Resolves #269 |
State: ca |
Site: los_angeles_gov |

## Notes
* none

## Data sample
```
var unfiltered = [
  {
    "id": 25,
    "xParent": 15,
    "NumChildren": 0,
    "inactive": "",
    "organization": "Reported",
    "name": "Crenshaw Clinic",
    "addr1": "1261 W 79th Street",
    "addr2": "Los Angeles, CA 90044",
    "vaccines": "m",
    "logo": "",
    "lat-lon": "33.96669248204296,-118.29743217895289",
    "lat": 33.96669248204296,
    "lon": -118.29743217895289,
    "mapZoom": "https://www.google.com/maps/d/embed?mid=1AdIIUb669F7mV6J5A6McJo7eC5X67dfG&ll=33.96669248204296%2C-118.29743217895289&z=16",
    "notes": "Run by LA City Fire Dept.",
    "notesSpn": "Dirigido por Departamento de Bomberos de la ciudad de Los Ángeles",
    "alt": "Tues-Sat 8am-4pm",
    "altSpn": "martes-sábado 8am-4pm",
    "date": "",
    "time": "",
    "link": "https://carbonhealth.com/covid-19-vaccines",
    "secondDose": "",
    "full": "",
    "comments": "",
    "commentsSpn": "",
    "times": [],
    "clinicFormat": 2,
    "system": "",
    "appointmentRequired": 1,
    "ADA": "",
    "paratransit": ""
  },
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
