### PR TITLE
Use schema in earlier normalizers

### DIFF
--- a/vaccine_feed_ingest/runners/ca/sf_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ca/sf_gov/normalize.py
@@ -5,8 +5,9 @@ import json
 import pathlib
 import sys
 
-from vaccine_feed_ingest.utils.normalize import provider_id_from_name
 from vaccine_feed_ingest_schema import location as schema
+
+from vaccine_feed_ingest.utils.normalize import provider_id_from_name
 
 
 def normalize(site: dict, timestamp: str) -> dict:
@@ -47,22 +48,22 @@ def normalize(site: dict, timestamp: str) -> dict:
                 contact_type="booking",
                 phone=site["booking"]["phone"],
                 website=site["booking"]["url"],
-                other=site["booking"]["info"]
-                ),
+                other=site["booking"]["info"],
+            ),
         ],
         languages=[k for k, v in site["access"]["languages"].items() if v],
         opening_dates=None,
         opening_hours=None,
         availability=schema.Availability(
             appointments=site["appointments"]["available"],
-            drop_in=site["booking"]["dropins"]
-            ),
+            drop_in=site["booking"]["dropins"],
+        ),
         inventory=None,
         access=schema.Access(
             walk=site["access_mode"]["walk"],
             drive=site["access_mode"]["drive"],
-            wheelchair="yes" if site["access"]["wheelchair"] else "no"
-            ),
+            wheelchair="yes" if site["access"]["wheelchair"] else "no",
+        ),
         parent_organization=None,
         links=links,
         notes=None,

--- a/vaccine_feed_ingest/runners/ca/sf_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ca/sf_gov/normalize.py
@@ -6,6 +6,7 @@ import pathlib
 import sys
 
 from vaccine_feed_ingest.utils.normalize import provider_id_from_name
+from vaccine_feed_ingest_schema import location as schema
 
 
 def normalize(site: dict, timestamp: str) -> dict:
@@ -19,61 +20,62 @@ def normalize(site: dict, timestamp: str) -> dict:
     if len(address_parts) > 1:
         street2 = ", ".join(address_parts[1:])
 
-    normalized = {
-        "id": f"sf_gov:{site['id']}",
-        "name": site["name"],
-        "address": {
-            "street1": street1,
-            "street2": street2,
-            "city": site["location"]["city"],
-            "state": "CA",
-            "zip": site["location"]["zip"],
-        },
-        "location": {
-            "latitude": site["location"]["lat"],
-            "longitude": site["location"]["lng"],
-        },
-        "contact": [
-            {
-                "contact_type": "booking",
-                "phone": site["booking"]["phone"],
-                "website": site["booking"]["url"],
-                "other": site["booking"]["info"],
-            },
-        ],
-        "availability": {
-            "appointments": site["appointments"]["available"],
-            "drop_in": site["booking"]["dropins"],
-        },
-        "access": {
-            "walk": site["access_mode"]["walk"],
-            "drive": site["access_mode"]["drive"],
-            "wheelchair": "yes" if site["access"]["wheelchair"] else "no",
-        },
-        "languages": [k for k, v in site["access"]["languages"].items() if v],
-        "links": [
-            {
-                "authority": "sf_gov",
-                "id": site["id"],
-            },
-        ],
-        "active": site["active"],
-        "source": {
-            "source": "sf_gov",
-            "id": site["id"],
-            "fetched_from_uri": "https://vaccination-site-microservice.vercel.app/api/v1/appointments",
-            "fetched_at": timestamp,
-            "published_at": site["appointments"]["last_updated"],
-            "data": site,
-        },
-    }
+    links = [schema.Link(authority="sf_gov", id=site["id"])]
 
     parsed_provider_link = provider_id_from_name(site["name"])
     if parsed_provider_link is not None:
-        normalized["links"].append(
-            {"authority": parsed_provider_link[0], "id": parsed_provider_link[1]}
+        links.append(
+            schema.Link(authority=parsed_provider_link[0], id=parsed_provider_link[1])
         )
-    return normalized
+
+    return schema.NormalizedLocation(
+        id=f"sf_gov:{site['id']}",
+        name=site["name"],
+        address=schema.Address(
+            street1=street1,
+            street2=street2,
+            city=site["location"]["city"],
+            state="CA",
+            zip=site["location"]["zip"],
+        ),
+        location=schema.LatLng(
+            latitude=site["location"]["lat"],
+            longitude=site["location"]["lng"],
+        ),
+        contact=[
+            schema.Contact(
+                contact_type="booking",
+                phone=site["booking"]["phone"],
+                website=site["booking"]["url"],
+                other=site["booking"]["info"]
+                ),
+        ],
+        languages=[k for k, v in site["access"]["languages"].items() if v],
+        opening_dates=None,
+        opening_hours=None,
+        availability=schema.Availability(
+            appointments=site["appointments"]["available"],
+            drop_in=site["booking"]["dropins"]
+            ),
+        inventory=None,
+        access=schema.Access(
+            walk=site["access_mode"]["walk"],
+            drive=site["access_mode"]["drive"],
+            wheelchair="yes" if site["access"]["wheelchair"] else "no"
+            ),
+        parent_organization=None,
+        links=links,
+        notes=None,
+        active=site["active"],
+        source=schema.Source(
+            source="sf_gov",
+            id=site["id"],
+            fetched_from_uri="https://vaccination-site-microservice.vercel.app/api/v1/appointments",  # noqa: E501
+            fetched_at=timestamp,
+            published_at=site["appointments"]["last_updated"],
+            data=site,
+        ),
+    ).dict()
 
 
 output_dir = pathlib.Path(sys.argv[1])

--- a/vaccine_feed_ingest/runners/ct/covidvaccinefinder_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ct/covidvaccinefinder_gov/normalize.py
@@ -55,7 +55,7 @@ def _get_lat_lng(site: dict) -> Optional[schema.LatLng]:
 def normalize(site: dict, timestamp: str) -> dict:
     links = [
         schema.Link(authority="ct_gov", id=site["_id"]),
-        schema.Link(authority="ct_gov:network_id", id=site["networkId"])
+        schema.Link(authority="ct_gov:network_id", id=site["networkId"]),
     ]
 
     parent_organization = schema.Organization(name=site["networks"][0]["name"])
@@ -81,21 +81,21 @@ def normalize(site: dict, timestamp: str) -> dict:
         location=_get_lat_lng(site),
         contact=[
             schema.Contact(
-                contact_type="booking",
-                phone=site["phone"],
-                website=site["link"]
-                ),
+                contact_type="booking", phone=site["phone"], website=site["link"]
+            ),
         ],
         languages=None,
         opening_dates=None,
         opening_hours=None,
         availability=schema.Availability(
             appointments=site["availability"],
-            ),
-        inventory=[{"vaccine": vaccine["name"]} for vaccine in site["providerVaccines"]],
+        ),
+        inventory=[
+            {"vaccine": vaccine["name"]} for vaccine in site["providerVaccines"]
+        ],
         access=schema.Access(
             drive=site["isDriveThru"],
-            ),
+        ),
         parent_organization=parent_organization,
         links=links,
         notes=None,

--- a/vaccine_feed_ingest/runners/ct/covidvaccinefinder_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ct/covidvaccinefinder_gov/normalize.py
@@ -53,68 +53,62 @@ def _get_lat_lng(site: dict) -> Optional[schema.LatLng]:
 
 
 def normalize(site: dict, timestamp: str) -> dict:
-    lat_lng = _get_lat_lng(site)
-    if lat_lng:
-        lat_lng = lat_lng.dict()
+    links = [
+        schema.Link(authority="ct_gov", id=site["_id"]),
+        schema.Link(authority="ct_gov:network_id", id=site["networkId"])
+    ]
 
-    normalized = {
-        "id": f"ct_gov:{site['_id']}",
-        "name": site["displayName"],
-        "address": {
-            "street1": site["addressLine1"],
-            "street2": site["addressLine2"],
-            "city": site["city"],
-            "state": "CT",
-            "zip": site["zip"],
-        },
-        "location": lat_lng,
-        "contact": [
-            {
-                "contact_type": "booking",
-                "phone": site["phone"],
-                "website": site["link"],
-            },
-        ],
-        "availability": {
-            "appointments": site["availability"],
-        },
-        "access": {
-            "drive": site["isDriveThru"],
-        },
-        "inventory": [
-            {"vaccine": vaccine["name"]} for vaccine in site["providerVaccines"]
-        ],
-        "links": [
-            {
-                "authority": "ct_gov",
-                "id": site["_id"],
-            },
-            {
-                "authority": "ct_gov:network_id",
-                "id": site["networkId"],
-            },
-        ],
-        "parent_organization": {
-            "name": site["networks"][0]["name"],
-        },
-        "source": {
-            "source": "ct",
-            "id": site["_id"],
-            "fetched_from_uri": "https://covidvaccinefinder.ct.gov/api/HttpTriggerGetProvider",
-            "fetched_at": timestamp,
-            "published_at": site["lastModified"],
-            "data": site,
-        },
-    }
+    parent_organization = schema.Organization(name=site["networks"][0]["name"])
 
     parsed_provider_link = provider_id_from_name(site["name"])
     if parsed_provider_link is not None:
-        normalized["links"].append(
-            {"authority": parsed_provider_link[0], "id": parsed_provider_link[1]}
+        links.append(
+            schema.Link(authority=parsed_provider_link[0], id=parsed_provider_link[1])
         )
-        normalized["parent_organization"]["id"] = parsed_provider_link[0]
 
-    return normalized
+        parent_organization.id = parsed_provider_link[0]
+
+    return schema.NormalizedLocation(
+        id=f"ct_gov:{site['_id']}",
+        name=site["displayName"],
+        address=schema.Address(
+            street1=site["addressLine1"],
+            street2=site["addressLine2"],
+            city=site["city"],
+            state="CT",
+            zip=site["zip"],
+        ),
+        location=_get_lat_lng(site),
+        contact=[
+            schema.Contact(
+                contact_type="booking",
+                phone=site["phone"],
+                website=site["link"]
+                ),
+        ],
+        languages=None,
+        opening_dates=None,
+        opening_hours=None,
+        availability=schema.Availability(
+            appointments=site["availability"],
+            ),
+        inventory=[{"vaccine": vaccine["name"]} for vaccine in site["providerVaccines"]],
+        access=schema.Access(
+            drive=site["isDriveThru"],
+            ),
+        parent_organization=parent_organization,
+        links=links,
+        notes=None,
+        active=None,
+        source=schema.Source(
+            source="covidvaccinefinder_gov",
+            id=site["_id"],
+            fetched_from_uri="https://covidvaccinefinder.ct.gov/api/HttpTriggerGetProvider",  # noqa: E501
+            fetched_at=timestamp,
+            published_at=site["lastModified"],
+            data=site,
+        ),
+    ).dict()
 
 
 output_dir = pathlib.Path(sys.argv[1])

--- a/vaccine_feed_ingest/runners/ny/am_i_eligible_covid19vaccine_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ny/am_i_eligible_covid19vaccine_gov/normalize.py
@@ -47,7 +47,7 @@ def _get_source(site_blob: dict, timestamp: str) -> schema.Source:
     )
 
 
-def normalize(site_blob: dict, timestamp: str) -> str:
+def normalize(site_blob: dict, timestamp: str) -> dict:
     """
     sample entry:
 
@@ -57,9 +57,13 @@ def normalize(site_blob: dict, timestamp: str) -> str:
     city = CITY_RE.search(site_blob["address"]).group(1)
     appts_available = True if site_blob["availableAppointments"] == "Y" else False
 
-    normalized = schema.NormalizedLocation(
+    return schema.NormalizedLocation(
         id=f"am_i_eligible_covid19vaccine_gov:{site_blob['providerId']}",
         name=name,
+        address=schema.Address(
+            city=city,
+            state="NY",
+        ),
         availability=schema.Availability(appointments=appts_available),
         inventory=_get_inventory(site_blob["vaccineBrand"]),
         links=[
@@ -69,8 +73,6 @@ def normalize(site_blob: dict, timestamp: str) -> str:
         ],
         source=_get_source(site_blob, timestamp),
     ).dict()
-    normalized["address"] = {"city": city, "state": "NY"}
-    return normalized
 
 
 parsed_at_timestamp = datetime.datetime.utcnow().isoformat()

--- a/vaccine_feed_ingest/runners/us/vaccinespotter_org/normalize.py
+++ b/vaccine_feed_ingest/runners/us/vaccinespotter_org/normalize.py
@@ -69,7 +69,7 @@ def normalize(site_blob: dict, timestamp: str) -> dict:
         site["provider_brand_name"]  # or use site["name"]?
     )
     if parsed_provider_link is not None:
-        normalized["links"].append(
+        links.append(
             schema.Link(authority=parsed_provider_link[0], id=parsed_provider_link[1])
         )
 
@@ -79,25 +79,16 @@ def normalize(site_blob: dict, timestamp: str) -> dict:
         address=_get_address(site),
         location=_get_lat_lng(site_blob["geometry"], site["id"]),
         contact=[
-            schema.Contact(
-                contact_type=None,
-                phone=None,
-                website=site["url"]
-                ),
+            schema.Contact(contact_type=None, phone=None, website=site["url"]),
         ],
         languages=None,
         opening_dates=None,
         opening_hours=None,
         availability=schema.Availability(
-            appointments=site["appointments_available"],
-            drop_in=None
-            ),
+            appointments=site["appointments_available"], drop_in=None
+        ),
         inventory=None,
-        access=schema.Access(
-            walk=None,
-            drive=None,
-            wheelchair=None
-            ),
+        access=schema.Access(walk=None, drive=None, wheelchair=None),
         parent_organization=None,
         links=links,
         notes=None,


### PR DESCRIPTION
| Key Details |
|-|
| Related #233 |

## Notes
Used the Pydantic schema for the following:

- ca/sf_gov
- ct/covidvaccinefinder_gov
- us/vaccinespotter_org
- ny/am_i_eligible_covid19vaccine_gov

Additionally, when updating `us/vaccinespotter_org`, we could be using `site["provider_brand_name"]` and `site["provider_brand_id"]` to populate the links & parent_org. There were a few edge cases I didn't want to tackle, but figured I should call it out here.

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
