### PR TITLE
fix: hardcode arizona to AZ

### DIFF
--- a/vaccine_feed_ingest/runners/az/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/az/arcgis/normalize.py
@@ -249,7 +249,7 @@ def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLoc
             street1=site["attributes"]["addr1"],
             street2=site["attributes"]["addr2"],
             city=site["attributes"]["city"],
-            state=site["attributes"]["state"] or "AZ",
+            state="AZ",
             zip=site["attributes"]["zip"],
         ),
         location=_get_lat_lng(site),


### PR DESCRIPTION
Downstream systems are currently receiving `az`, `AZ`, and `Arizona`. Hardcode to `AZ`.