### PR TITLE
ci: run modified runners except for us/*

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -120,6 +120,10 @@ jobs:
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         working-directory: vaccine-feed-ingest
 
+      - name: ensure cli starts
+        working-directory: vaccine-feed-ingest
+        run: poetry run vaccine-feed-ingest --help
+
       - name: list runners to run
         working-directory: vaccine-feed-ingest
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,6 +78,66 @@ jobs:
           rm -f .tox/lint/log/*
 
 
+  run-pipeline:
+    name: Run all-stages for modified runners
+    runs-on: ubuntu-latest
+    steps:
+      - name: apt-get dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libbz2-dev liblzma-dev libreadline-dev libsqlite3-dev
+
+      - uses: actions/checkout@v2
+        with:
+          repository: CAVaccineInventory/vaccine-feed-ingest
+          path: ./vaccine-feed-ingest/
+          submodules: true
+          fetch-depth: 0
+
+      - name: get python version
+        working-directory: vaccine-feed-ingest
+        run: |
+          python_version=$(cat .python-version)
+          echo "python_version=${python_version}" >> $GITHUB_ENV
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.python_version }}
+
+      - name: setup from README.md
+        run: |
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+
+      - name: load poetry install from cache
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: vaccine-feed-ingest/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      - run: poetry install --extras lint
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        working-directory: vaccine-feed-ingest
+
+      - name: list runners to run
+        working-directory: vaccine-feed-ingest
+        run: |
+          git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | \
+            grep "vaccine_feed_ingest/runners/[^._]" | \
+            sed -E "s#vaccine_feed_ingest/runners/([^/]+)/([^/]+)/.*#\1/\2#" | \
+            grep -v "us/"
+
+      - name: run selected runners
+        working-directory: vaccine-feed-ingest
+        run: |
+          git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | \
+            grep "vaccine_feed_ingest/runners/[^._]" | \
+            sed -E "s#vaccine_feed_ingest/runners/([^/]+)/([^/]+)/.*#\1/\2#" | \
+            grep -v "us/" | \
+            xargs poetry run vaccine-feed-ingest all-stages
+
+
   repo-linter:
     name: SuperLinter
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -124,22 +124,24 @@ jobs:
         working-directory: vaccine-feed-ingest
         run: poetry run vaccine-feed-ingest --help
 
-      - name: list runners to run
+      - name: calculate runners to run
         working-directory: vaccine-feed-ingest
         run: |
           git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | \
             grep "vaccine_feed_ingest/runners/[^._]" | \
             sed -E "s#vaccine_feed_ingest/runners/([^/]+)/([^/]+)/.*#\1/\2#" | \
-            grep -v "us/"
+            grep -v "us/" > ../runners_to_run.txt || true
 
       - name: run selected runners
         working-directory: vaccine-feed-ingest
         run: |
-          git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | \
-            grep "vaccine_feed_ingest/runners/[^._]" | \
-            sed -E "s#vaccine_feed_ingest/runners/([^/]+)/([^/]+)/.*#\1/\2#" | \
-            grep -v "us/" | \
-            xargs poetry run vaccine-feed-ingest all-stages
+          if [[ -f ../runners_to_run.txt ]]; then
+            echo "will run the following runners"
+            cat ../runners_to_run.txt
+            cat ../runners_to_run.txt | xargs poetry run vaccine-feed-ingest all-stages
+          else
+            echo "no runners to run"
+          fi
 
 
   repo-linter:


### PR DESCRIPTION
Add a CI job which:
* runs `poetry run vaccine-feed-ingest --help` after performing environment setup. This will prevent PRs from merging which fundamentally break the CLI (e.g., invalid imports, etc.)
* if a runner was modified (other than `us/*`), run `all-stages` for that runner! This will prevent runners which do not run from being merged (outside of the `us/` directory)

⚠️ After this is merged, CI jobs will interact with external sites to perform the `fetch` stage. If additional large sites are brought into the pipeline outside of the `us/*` directory, we may need to add exemptions for them also.

🔗 [Here is a sample CI run of a PR which modified runners](https://github.com/CAVaccineInventory/vaccine-feed-ingest/pull/286/checks?check_run_id=2464296658). In that PR I modified the following files:
```txt
.github/workflows/lint.yml
vaccine_feed_ingest/runners/_template/normalize.sh
vaccine_feed_ingest/runners/az/arcgis/fetch.yml
vaccine_feed_ingest/runners/ca/metrolink/parse.py
vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/fetch.yml
vaccine_feed_ingest/stages/ingest.py
```
...but (as desired), only the following runners ran:
```txt
az/arcgis
ca/metrolink
```