### PR TITLE
ci: force rebase job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,13 @@ jobs:
           workflows: '[".github/workflows/*.yml"]'
 
 
+  force-rebase-schema-1-0-0:
+    name: You must rebase and install to get new schema v1.0.0
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "If you fail this job, you must rebase on main and then run poetry install --extras lint"
+
+
   tox:
     name: Python Lint & Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
As shared in #278, we plan to release `v1.0.0` of the schema. When it is released, all open PRs will need to be updated to include it properly.

Once the PR bumping the schema is merged, merge this PR and require it as a PR check.
* Old branches will fail the required check (because it is not defined)
  ![image](https://user-images.githubusercontent.com/3347571/116513796-f5e98680-a87e-11eb-8c83-bce5c37c5cc7.png)
* New branches will pass the required check (because it simply echos a value)
  ![image](https://user-images.githubusercontent.com/3347571/116514121-6db7b100-a87f-11eb-94d1-888d0726711e.png)