### PR TITLE
ci(runner): skip running runners outside of prs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -136,7 +136,7 @@ jobs:
       - name: run selected runners
         working-directory: vaccine-feed-ingest
         run: |
-          if [[ -f ../runners_to_run.txt ]]; then
+          if [[ -s ../runners_to_run.txt ]]; then
             echo "will run the following runners"
             cat ../runners_to_run.txt
             cat ../runners_to_run.txt | xargs poetry run vaccine-feed-ingest all-stages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,6 +81,7 @@ jobs:
   run-pipeline:
     name: Run all-stages for modified runners
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: apt-get dependencies
         run: |


### PR DESCRIPTION
This job targets modified runners in the context of a PR. It does not make sense to run it outside that context, because too many runners will be selected.

Additionally, use `-s` rather than `-f` to attempt to enforce that the instruction file is non-empty.