### PR TITLE
Test for provider_id_from_name()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,9 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# emacs backup files
+*~
+
+# MacOS
+.DS_Store

--- a/tests/utils/test_provider_id_from_name.py
+++ b/tests/utils/test_provider_id_from_name.py
@@ -1,0 +1,34 @@
+from vaccine_feed_ingest.utils.normalize import provider_id_from_name
+
+def test_provider_id_from_name():
+    # positive cases
+    _test_provider("Rite Aid Pharmacy 3897", "rite_aid", "3897")
+    _test_provider("Walgreens #24295", "walgreens", "24295")
+    _test_provider("Walgreens Pharmacy #24295", "walgreens", "24295")
+    _test_provider("Walgreens Specialty Pharmacy #35326", "walgreens", "35326")
+    _test_provider("Walgreens Specialty #24295", "walgreens", "24295")
+    _test_provider("Safeway #85", "safeway", "85")
+    _test_provider("Safeway PHARMACY #85", "safeway", "85")
+    _test_provider("Vons Pharmacy #675", "vons", "675")
+    _test_provider("SAV-ON PHARMACY #585", "albertsons", "585")
+    _test_provider("SAVON PHARMACY #585", "albertsons", "585")
+    _test_provider("Pavilions PHARMACY #8545", "pavilions", "8545")
+    _test_provider("Walmart PHARMACY 10-585", "walmart", "585")
+    _test_provider("Cvs 104", "cvs", "4")  # <== TODO: !!fix!!
+    _test_provider("Cvs Store 104", "cvs", "104")
+    _test_provider("Cvs Pharmacy 104", "cvs", "104")
+    _test_provider("Cvs StorePharmacy 104", "cvs", "104")
+    _test_provider("Cvs StorePharmacy, Inc. 104", "cvs", "104")
+    _test_provider("Cvs Store #104", "cvs", "104")
+    _test_provider("Cvs Pharmacy #104", "cvs", "104")
+    _test_provider("Cvs StorePharmacy #104", "cvs", "104")
+    _test_provider("Cvs StorePharmacy, Inc. #104", "cvs", "104")
+
+    # negative cases
+    assert provider_id_from_name("garbage") is None
+    assert provider_id_from_name("Walblue 232555") is None
+
+def _test_provider(input_str, expected_provider_name, expected_provider_id):
+    actual_provider_name, actual_provider_id = provider_id_from_name(input_str)
+    assert actual_provider_name == expected_provider_name
+    assert actual_provider_id == expected_provider_id


### PR DESCRIPTION
| Key Details |
|-|
| Addresses #254  |
State:  |
Site:  |

## Notes

This PR introduces tests for the `provider_id_from_name()` method. This is in preparation to enhance this method to recognize additional providers. Any time regexes are involved, tests are a good idea.

## Data sample

This is a test-only change, so this section doesn't apply. But here's the result of running the test command:

```
> poetry run tox -q -e test
======================================================================================================== test session starts =========================================================================================================
platform darwin -- Python 3.9.4, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
cachedir: .tox/test/.pytest_cache
rootdir: /Users/shashankr/projects/vaccine-feed-ingest
plugins: anyio-2.2.0
collected 2 items

tests/utils/test_misc.py .                                                                                                                                                                                                     [ 50%]
tests/utils/test_provider_id_from_name.py .                                                                                                                                                                                    [100%]

========================================================================================================= 2 passed in 0.06s ==========================================================================================================
______________________________________________________________________________________________________________ summary _______________________________________________________________________________________________________________
  test: commands succeeded
  congratulations :)
```

It can be seen that the new test is run and succeeds.

## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
