### PR TITLE
setup.sh for linux

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -55,6 +55,7 @@ setup_linux() {
         echo ""
         echo "We don't yet have automated setup for RPM-based distributions"
         echo "and would be absolutely delighted to take a patch."
+        exit 1
     fi
 
     echo "Installing dependencies"

--- a/setup.sh
+++ b/setup.sh
@@ -63,7 +63,13 @@ setup_linux() {
     echo "I'm about to use sudo to install some libraries, python 3.9, and curl"
     echo "so will ask for your root password"
     echo ""
-    sudo apt-get install libbz2-dev liblzma-dev libreadline-dev libsqlite3-dev python3.9 curl
+    sudo apt-get install \
+        libbz2-dev \
+        liblzma-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        python3.9 \
+        curl
 
     curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3.9 -
 

--- a/setup.sh
+++ b/setup.sh
@@ -85,6 +85,6 @@ fi
 
 case "$OSTYPE" in
 darwin*) setup_macos ;;
-#linux*)   setup_linux ;;
+linux*) setup_linux ;;
 *) setup_unsupported ;;
 esac

--- a/setup.sh
+++ b/setup.sh
@@ -69,6 +69,7 @@ setup_linux() {
         libreadline-dev \
         libsqlite3-dev \
         python3.9 \
+        python3-pip \
         curl
 
     curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3.9 -

--- a/setup.sh
+++ b/setup.sh
@@ -74,8 +74,15 @@ setup_linux() {
 
     curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3.9 -
 
+    echo "Installing all of our python dependencies using Poetry."
+
     "$HOME"/.local/bin/poetry install --extras lint
 
+    echo "Install done."
+    echo ""
+    echo "Try this command next:"
+    echo ""
+    echo "poetry run vaccine-feed-ingest --help"
 }
 
 setup_unsupported() {

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# exit when a command fails instead of blindly blundering forward
+set -e
+# treat unset variables as an error and exit immediately
+set -u
+# don't hide exit codes when pipeline output to another command
+set -o pipefail
+
 maybe_install() {
 
     exists=$(which "$1")

--- a/setup.sh
+++ b/setup.sh
@@ -71,9 +71,9 @@ setup_linux() {
         python3.9 \
         curl
 
-    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3.9 -
+    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3.9 -
 
-    "$HOME"/.poetry/bin/poetry install --extras lint
+    "$HOME"/.local/bin/poetry install --extras lint
 
 }
 


### PR DESCRIPTION
# Enable setup.sh for linux

A lower friction setup helps more folks to contribute.

## Notes

I tested this in an Ubuntu container with `sudo` temporary removed from the `setup.sh` script.

test Dockerfile:

```Dockerfile
FROM ubuntu

RUN apt-get update && \
  apt-get upgrade -y && \
  apt-get install -y \
    git

WORKDIR /code/
RUN git clone https://github.com/CAVaccineInventory/vaccine-feed-ingest.git
WORKDIR /code/vaccine-feed-ingest
COPY setup.sh ./
```


Temporary patch to remove sudo so it will run in a container
```diff
--- a/setup.sh
+++ b/setup.sh
@@ -63,7 +63,7 @@ setup_linux() {
     echo "I'm about to use sudo to install some libraries, python 3.9, and curl"
     echo "so will ask for your root password"
     echo ""
-    sudo apt-get install \
+    apt-get install \
       libbz2-dev \
       liblzma-dev \
       libreadline-dev \
```

Tested with 

```sh
# build the container
docker build --progress=plain -t test .
# run the container in interactive mode
docker run --rm -it test bash

# in the container, run setup
./setup.sh
# verify the setup worked
$HOME/.local/bin/poetry run vaccine-feed-ingest --help
```