### PR TITLE
Add enrich stage between normalize and load

### DIFF
--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -200,6 +200,25 @@ def all_stages(
 
 
 @cli.command()
+@_state_option()
+@_output_dir_option()
+@_dry_run_option()
+@_sites_argument()
+def enrich(
+    state: Optional[str],
+    output_dir: pathlib.Path,
+    dry_run: bool,
+    sites: Optional[Sequence[str]],
+) -> None:
+    """Run enrich process for specified sites."""
+    timestamp = _generate_run_timestamp()
+    site_dirs = site.get_site_dirs(state, sites)
+
+    for site_dir in site_dirs:
+        ingest.run_enrich(site_dir, output_dir, timestamp, dry_run)
+
+
+@cli.command()
 @click.option(
     "--vial-server",
     "vial_server",

--- a/vaccine_feed_ingest/stages/common.py
+++ b/vaccine_feed_ingest/stages/common.py
@@ -14,6 +14,7 @@ class PipelineStage(str, enum.Enum):
     FETCH = "fetch"
     PARSE = "parse"
     NORMALIZE = "normalize"
+    ENRICH = "enrich"
 
 
 # Root name for command or config to run for each stage e.g. fetch.py
@@ -29,6 +30,7 @@ STAGE_OUTPUT_NAME = {
     PipelineStage.FETCH: "raw",
     PipelineStage.PARSE: "parsed",
     PipelineStage.NORMALIZE: "normalized",
+    PipelineStage.ENRICH: "enriched",
 }
 
 
@@ -36,4 +38,5 @@ STAGE_OUTPUT_NAME = {
 STAGE_OUTPUT_SUFFIX = {
     PipelineStage.PARSE: ".parsed.ndjson",
     PipelineStage.NORMALIZE: ".normalized.ndjson",
+    PipelineStage.ENRICH: ".enriched.ndjson",
 }

--- a/vaccine_feed_ingest/stages/enrichment.py
+++ b/vaccine_feed_ingest/stages/enrichment.py
@@ -1,0 +1,56 @@
+"""Method for enriching location records after that are normalized"""
+import logging
+import pathlib
+
+import pydantic
+from vaccine_feed_ingest_schema import location
+
+from . import outputs
+from .common import STAGE_OUTPUT_SUFFIX, PipelineStage
+
+logger = logging.getLogger("enrichment")
+
+
+def enrich_locations(input_dir: pathlib.Path, output_dir: pathlib.Path) -> bool:
+    """Enrich locations in normalized input_dir and write them to output_dir"""
+    enriched_locations = []
+
+    for filepath in outputs.iter_data_paths(
+        input_dir, suffix=STAGE_OUTPUT_SUFFIX[PipelineStage.NORMALIZE]
+    ):
+        with filepath.open() as src_file:
+            for line in src_file:
+                try:
+                    normalized_location = location.NormalizedLocation.parse_raw(line)
+                except pydantic.ValidationError as e:
+                    logger.warning(
+                        "Skipping source location because it is invalid: %s\n%s",
+                        line,
+                        str(e),
+                    )
+                    continue
+
+                enriched_location = _process_location(normalized_location)
+
+                if not enriched_location:
+                    continue
+
+                enriched_locations.append(enriched_location)
+
+    if not enriched_locations:
+        return False
+
+    suffix = STAGE_OUTPUT_SUFFIX[PipelineStage.ENRICH]
+    dst_filepath = output_dir / f"locations{suffix}"
+
+    with dst_filepath.open("w") as dst_file:
+        for loc in enriched_locations:
+            dst_file.write(loc.json())
+            dst_file.write("\n")
+
+    return True
+
+
+def _process_location(loc: location.NormalizedLocation) -> location.NormalizedLocation:
+    """Run throuch all of the methods to enrich the location"""
+    return loc

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -30,26 +30,26 @@ def run_load_to_vial(
     dry_run: bool = False,
 ) -> Optional[List[load.ImportSourceLocation]]:
     """Load source to vial source locations"""
-    normalize_run_dir = outputs.find_latest_run_dir(
-        output_dir, site_dir.parent.name, site_dir.name, PipelineStage.NORMALIZE
+    ennrich_run_dir = outputs.find_latest_run_dir(
+        output_dir, site_dir.parent.name, site_dir.name, PipelineStage.ENRICH
     )
-    if not normalize_run_dir:
+    if not ennrich_run_dir:
         logger.warning(
-            "Skipping load for %s because there is no data from normalize stage",
+            "Skipping load for %s because there is no data from enrich stage",
             site_dir.name,
         )
         return None
 
     if not outputs.data_exists(
-        normalize_run_dir, suffix=STAGE_OUTPUT_SUFFIX[PipelineStage.NORMALIZE]
+        ennrich_run_dir, suffix=STAGE_OUTPUT_SUFFIX[PipelineStage.ENRICH]
     ):
-        logger.warning("No normalize data available to load for %s.", site_dir.name)
+        logger.warning("No enriched data available to load for %s.", site_dir.name)
         return None
 
     num_imported_locations = 0
 
     for filepath in outputs.iter_data_paths(
-        normalize_run_dir, suffix=STAGE_OUTPUT_SUFFIX[PipelineStage.NORMALIZE]
+        ennrich_run_dir, suffix=STAGE_OUTPUT_SUFFIX[PipelineStage.ENRICH]
     ):
         import_locations = []
         with filepath.open() as src_file:


### PR DESCRIPTION
Add a bare bones `enrich` stage that processes the normalized records from ingestors and prepares them for load.

```
vaccine-feed-ingest enrich ca/sf_gov
```

Right now this stage copies all locations that pass validation, but in the future it will:
1. Ensure a full address for all locations (street, city, state, zip) if possible
2. Ensure lat-lng exists using a geocoder
3. Fill out parent_organization based on name
4. Fill out concordances from parent_organization, source, and name
5. Match to external concordances like google places, OSM POI, or Placekey (if api pricing and limits allow)