### PR TITLE
Add pipeline command to cli that runs all stages from fetch to load

### DIFF
--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -13,7 +13,6 @@ import click
 import dotenv
 import pathy
 
-from . import vial
 from .stages import common, ingest, load, site
 
 # Configure logger
@@ -287,35 +286,16 @@ def load_to_vial(
     """Load specified sites to vial server."""
     site_dirs = site.get_site_dirs(state, sites)
 
-    with vial.vial_client(vial_server, vial_apikey) as vial_http:
-        import_run_id = vial.start_import_run(vial_http)
-
-        if enable_match or enable_create:
-            locations = vial.retrieve_existing_locations_as_index(vial_http)
-
-        for site_dir in site_dirs:
-            imported_locations = load.run_load_to_vial(
-                vial_http,
-                site_dir,
-                output_dir,
-                import_run_id,
-                locations,
-                enable_match=enable_match,
-                enable_create=enable_create,
-                candidate_distance=candidate_distance,
-                dry_run=dry_run,
-            )
-
-            # If data was loaded then refresh existing locations
-            if locations is not None and imported_locations:
-                source_ids = [
-                    loc.source_uid
-                    for loc in imported_locations
-                    if loc.match and loc.match.action == "new"
-                ]
-
-                if source_ids:
-                    vial.update_existing_locations(vial_http, locations, source_ids)
+    load.load_sites_to_vial(
+        site_dirs,
+        output_dir,
+        dry_run,
+        vial_server,
+        vial_apikey,
+        enable_match,
+        enable_create,
+        candidate_distance,
+    )
 
 
 @cli.command()

--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -110,15 +110,15 @@ def _compute_has_parse(site_dir: pathlib.Path) -> bool:
 
 
 @cli.command()
+@_sites_argument()
 @_state_option()
 @_output_dir_option()
 @_dry_run_option()
-@_sites_argument()
 def fetch(
+    sites: Optional[Sequence[str]],
     state: Optional[str],
     output_dir: pathlib.Path,
     dry_run: bool,
-    sites: Optional[Sequence[str]],
 ) -> None:
     """Run fetch process for specified sites."""
     timestamp = _generate_run_timestamp()
@@ -129,17 +129,17 @@ def fetch(
 
 
 @cli.command()
+@_sites_argument()
 @_state_option()
 @_output_dir_option()
-@_validate_option()
 @_dry_run_option()
-@_sites_argument()
+@_validate_option()
 def parse(
+    sites: Optional[Sequence[str]],
     state: Optional[str],
     output_dir: pathlib.Path,
-    validate: bool,
     dry_run: bool,
-    sites: Optional[Sequence[str]],
+    validate: bool,
 ) -> None:
     """Run parse process for specified sites."""
     timestamp = _generate_run_timestamp()
@@ -150,17 +150,17 @@ def parse(
 
 
 @cli.command()
+@_sites_argument()
 @_state_option()
 @_output_dir_option()
-@_validate_option()
 @_dry_run_option()
-@_sites_argument()
+@_validate_option()
 def normalize(
+    sites: Optional[Sequence[str]],
     state: Optional[str],
     output_dir: pathlib.Path,
-    validate: bool,
     dry_run: bool,
-    sites: Optional[Sequence[str]],
+    validate: bool,
 ) -> None:
     """Run normalize process for specified sites."""
     timestamp = _generate_run_timestamp()
@@ -171,15 +171,13 @@ def normalize(
 
 
 @cli.command()
-@_state_option()
-@_validate_option()
-@_output_dir_option()
 @_sites_argument()
+@_state_option()
+@_output_dir_option()
 def all_stages(
-    state: Optional[str],
-    validate: bool,
-    output_dir: pathlib.Path,
     sites: Optional[Sequence[str]],
+    state: Optional[str],
+    output_dir: pathlib.Path,
 ) -> None:
     """Run all stages in succession for specified sites."""
     timestamp = _generate_run_timestamp()
@@ -191,24 +189,24 @@ def all_stages(
         if not fetch_success:
             continue
 
-        parse_success = ingest.run_parse(site_dir, output_dir, timestamp, validate)
+        parse_success = ingest.run_parse(site_dir, output_dir, timestamp)
 
         if not parse_success:
             continue
 
-        ingest.run_normalize(site_dir, output_dir, timestamp, validate)
+        ingest.run_normalize(site_dir, output_dir, timestamp)
 
 
 @cli.command()
+@_sites_argument()
 @_state_option()
 @_output_dir_option()
 @_dry_run_option()
-@_sites_argument()
 def enrich(
+    sites: Optional[Sequence[str]],
     state: Optional[str],
     output_dir: pathlib.Path,
     dry_run: bool,
-    sites: Optional[Sequence[str]],
 ) -> None:
     """Run enrich process for specified sites."""
     timestamp = _generate_run_timestamp()
@@ -219,6 +217,10 @@ def enrich(
 
 
 @cli.command()
+@_sites_argument()
+@_state_option()
+@_output_dir_option()
+@_dry_run_option()
 @click.option(
     "--vial-server",
     "vial_server",
@@ -233,10 +235,6 @@ def enrich(
     type=str,
     default=lambda: os.environ.get("VIAL_APIKEY", ""),
 )
-@_state_option()
-@_output_dir_option()
-@_dry_run_option()
-@_sites_argument()
 @click.option(
     "--match/--no-match",
     "enable_match",
@@ -256,12 +254,12 @@ def enrich(
     default=CANDIDATE_DEGREES_DISTANCE,
 )
 def load_to_vial(
-    vial_server: str,
-    vial_apikey: str,
+    sites: Optional[Sequence[str]],
     state: Optional[str],
     output_dir: pathlib.Path,
     dry_run: bool,
-    sites: Optional[Sequence[str]],
+    vial_server: str,
+    vial_apikey: str,
     enable_match: bool,
     enable_create: bool,
     candidate_distance: float,

--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -73,6 +73,53 @@ def _sites_argument() -> Callable:
     return click.argument("sites", nargs=-1, type=str)
 
 
+def _vial_server_option() -> Callable:
+    return click.option(
+        "--vial-server",
+        "vial_server",
+        type=str,
+        default=lambda: os.environ.get(
+            "VIAL_SERVER", "https://vial-staging.calltheshots.us"
+        ),
+    )
+
+
+def _vial_apikey_option() -> Callable:
+    return click.option(
+        "--vial-apikey",
+        "vial_apikey",
+        type=str,
+        default=lambda: os.environ.get("VIAL_APIKEY", ""),
+    )
+
+
+def _match_option() -> Callable:
+    return click.option(
+        "--match/--no-match",
+        "enable_match",
+        type=bool,
+        default=lambda: os.environ.get("ENABLE_MATCH", "true").lower() == "true",
+    )
+
+
+def _create_option() -> Callable:
+    return click.option(
+        "--create/--no-create",
+        "enable_create",
+        type=bool,
+        default=lambda: os.environ.get("ENABLE_CREATE", "false").lower() == "true",
+    )
+
+
+def _candidate_distance_option() -> Callable:
+    return click.option(
+        "--candidate-distance",
+        "candidate_distance",
+        type=float,
+        default=CANDIDATE_DEGREES_DISTANCE,
+    )
+
+
 @click.group()
 def cli():
     """Run vaccine-feed-ingest commands"""
@@ -221,38 +268,11 @@ def enrich(
 @_state_option()
 @_output_dir_option()
 @_dry_run_option()
-@click.option(
-    "--vial-server",
-    "vial_server",
-    type=str,
-    default=lambda: os.environ.get(
-        "VIAL_SERVER", "https://vial-staging.calltheshots.us"
-    ),
-)
-@click.option(
-    "--vial-apikey",
-    "vial_apikey",
-    type=str,
-    default=lambda: os.environ.get("VIAL_APIKEY", ""),
-)
-@click.option(
-    "--match/--no-match",
-    "enable_match",
-    type=bool,
-    default=lambda: os.environ.get("ENABLE_MATCH", "true").lower() == "true",
-)
-@click.option(
-    "--create/--no-create",
-    "enable_create",
-    type=bool,
-    default=lambda: os.environ.get("ENABLE_CREATE", "false").lower() == "true",
-)
-@click.option(
-    "--candidate-distance",
-    "candidate_distance",
-    type=float,
-    default=CANDIDATE_DEGREES_DISTANCE,
-)
+@_vial_server_option()
+@_vial_apikey_option()
+@_match_option()
+@_create_option()
+@_candidate_distance_option()
 def load_to_vial(
     sites: Optional[Sequence[str]],
     state: Optional[str],

--- a/vaccine_feed_ingest/stages/common.py
+++ b/vaccine_feed_ingest/stages/common.py
@@ -15,6 +15,7 @@ class PipelineStage(str, enum.Enum):
     PARSE = "parse"
     NORMALIZE = "normalize"
     ENRICH = "enrich"
+    LOAD_TO_VIAL = "load-to-vial"
 
 
 # Root name for command or config to run for each stage e.g. fetch.py

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -1,6 +1,6 @@
 import logging
 import pathlib
-from typing import Iterator, List, Optional
+from typing import Iterable, Iterator, List, Optional
 
 import jellyfish
 import pydantic
@@ -18,16 +18,58 @@ from .common import STAGE_OUTPUT_SUFFIX, PipelineStage
 logger = logging.getLogger("load")
 
 
+def load_sites_to_vial(
+    site_dirs: Iterable[pathlib.Path],
+    output_dir: pathlib.Path,
+    dry_run: bool,
+    vial_server: str,
+    vial_apikey: str,
+    enable_match: bool,
+    enable_create: bool,
+    candidate_distance: float,
+) -> None:
+    """Load list of sites to vial"""
+    with vial.vial_client(vial_server, vial_apikey) as vial_http:
+        import_run_id = vial.start_import_run(vial_http)
+
+        if enable_match or enable_create:
+            locations = vial.retrieve_existing_locations_as_index(vial_http)
+
+        for site_dir in site_dirs:
+            imported_locations = run_load_to_vial(
+                site_dir,
+                output_dir,
+                dry_run=dry_run,
+                vial_http=vial_http,
+                import_run_id=import_run_id,
+                locations=locations,
+                enable_match=enable_match,
+                enable_create=enable_create,
+                candidate_distance=candidate_distance,
+            )
+
+            # If data was loaded then refresh existing locations
+            if locations is not None and imported_locations:
+                source_ids = [
+                    loc.source_uid
+                    for loc in imported_locations
+                    if loc.match and loc.match.action == "new"
+                ]
+
+                if source_ids:
+                    vial.update_existing_locations(vial_http, locations, source_ids)
+
+
 def run_load_to_vial(
-    vial_http: urllib3.connectionpool.ConnectionPool,
     site_dir: pathlib.Path,
     output_dir: pathlib.Path,
+    dry_run: bool,
+    vial_http: urllib3.connectionpool.ConnectionPool,
     import_run_id: str,
     locations: Optional[rtree.index.Index],
     enable_match: bool = True,
     enable_create: bool = False,
     candidate_distance: float = 0.6,
-    dry_run: bool = False,
 ) -> Optional[List[load.ImportSourceLocation]]:
     """Load source to vial source locations"""
     ennrich_run_dir = outputs.find_latest_run_dir(


### PR DESCRIPTION
Add pipeline command to cli that can run all stages from fetch to load, and allows you to customize which stages to run.

Run just normalize:
```
vaccine-feed-ingest pipeline ca/sf_gov --stages=normalize
```

Run ingestion part:
```
vaccine-feed-ingest pipeline ca/sf_gov --stages=fetch,parse,normalize
```

Run load part:
```
vaccine-feed-ingest pipeline ca/sf_gov --stages=enrich,load-to-vial
```