### PR TITLE
expand address parsing for in/arcgis

### DIFF
--- a/vaccine_feed_ingest/runners/in/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/in/arcgis/normalize.py
@@ -33,7 +33,7 @@ def _get_id(site: dict) -> str:
     arcgis = "46630b2520ce44a68a9f42f8343d3518"
     layer = 0
 
-    return f"{runner}_{site_name}:{arcgis}_{layer}:{data_id}"
+    return f"{runner}_{site_name}:{arcgis}_{layer}_{data_id}"
 
 
 def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:

--- a/vaccine_feed_ingest/runners/in/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/in/arcgis/normalize.py
@@ -106,20 +106,79 @@ def _get_notes(site: dict) -> Optional[List[str]]:
     return None
 
 
+# address is loosely structured and inconsistent, so we're going to bash our
+# way through it, mostly parsing from the end of the string
 def _get_address(site: dict) -> schema.Address:
     address = site["attributes"]["Site_Address"]
-    address_split = address.split(",")
+    address = address.replace("  ", " ")
+    address = address.replace("  ", " ")
+    address = address.replace(" ,", ",")
+    address = address.replace(",,", ",")
+    address = address.lstrip()
+    address = address.rstrip()
 
-    # TODO: improve address parsing to minimize unknown addresses
-    if len(address_split) != 3:
-        logger.warning(f"Unparseable address: {address}")
-        return None
+    # pull an address note off the end
+    address_note = ""
+    if match := re.search(" [(](.*)[)]$", address):
+        address_note = f" ({match.group(1)})"
+        address = address.rstrip(f" ({address_note})")
+    else:
+        address_note = None
+
+    # pull a zip code off the end
+    zip = None
+    if match := re.search(" (\\d\\d\\d\\d\\d-\\d\\d\\d\\d)$", address):
+        zip = match.group(1)
+        address = address.rstrip(f" {zip}")
+    if match := re.search(" (\\d\\d\\d\\d\\d)$", address):
+        zip = match.group(1)
+        address = address.rstrip(f" {zip}")
+
+    state = "IN"
+    address = address.rstrip()
+    address = address.rstrip(",")
+    address = address.rstrip(".")
+    address = address.rstrip(f" {state}")
+    address = address.rstrip()
+    address = address.rstrip(",")
+
+    # here are some patterns that might be remaining at this point:
+    # street1
+    # street1 city
+    # street1, city
+    # street1, street2
+    # street1, street2 city
+    # street1, street2, city
+    #
+    # so let's:
+    # a) use the first ,-separated token as street1
+    # b) if exactly 1 ,-separated token, use the last word as city
+    # c) if exactly 2 ,-separated tokens, use the second as street2 *and* city
+    # d) if >2 ,-separated tokens, use last as city and [1:-1] as street2
+    #
+    # some of these are going to be malformed, but hopefully the few that are
+    # will be relatively easy for humans to recover. Case (c) is relatively
+    # common, but setting street2:=city is relatively benign.
+
+    address_split = address.split(",")
+    street1 = address_split[0]
+    street2 = ""
+    city = ""
+    if len(address_split) == 1:
+        city = address_split[0].split()[-1]
+    if len(address_split) == 2:
+        street2 = address_split[1].lstrip().rstrip()
+        city = address_split[1].lstrip().rstrip()
+    if len(address_split) > 2:
+        street2 = ",".join(address_split[1:-1]).lstrip().rstrip()
+        city = address_split[-1].lstrip().rstrip()
 
     return schema.Address(
-        street1=address_split[0].strip(),
-        city=address_split[-2].strip(),
-        state="IN",
-        zip=address_split[-1].replace("IN", "").strip(),
+        street1=street1,
+        street2=f"{street2}{address_note}",
+        city=city,
+        state=state,
+        zip=zip,
     )
 
 


### PR DESCRIPTION
# normalize arcgis for in

| Key Details |
|-|
| Resolves #231 |
State: in |
Site: arcgis |

## Notes
* It's easy enough to pull zip and state off the end, and then we get to this point:
```{python}
    # here are some patterns that might be remaining at this point:
    # street1
    # street1 city
    # street1, city
    # street1, street2
    # street1, street2 city
    # street1, street2, city
    #
    # so let's:
    # a) use the first ,-separated token as street1
    # b) if exactly 1 ,-separated token, use the last word as city
    # c) if exactly 2 ,-separated tokens, use the second as street2 *and* city
    # d) if >2 ,-separated tokens, use last as city and [1:-1] as street2
    #
    # some of these are going to be malformed, but hopefully the few that are
    # will be relatively easy for humans to recover. Case (c) is relatively
    # common, but setting street2:=city is relatively benign.
```

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```json
{"id": "in:arcgis:46630b2520ce44a68a9f42f8343d3518_0:cbdadf08-4e7d-4946-b730-bc5db81cae77", "name": "Adams Memorial Hospital", "address": {"street1": "1100 Mercer Ave", "street2": "Decatur", "city": "Decatur", "state": "IN", "zip": "46733"}, "location": {"latitude": 40.81772566014207, "longitude": -84.91267832291557}, "contact": [{"contact_type": null, "phone": null, "website": "https://vaccine.coronavirus.in.gov", "email": null, "other": null}], "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": [{"vaccine": "moderna", "supply_level": null}], "access": null, "parent_organization": null, "links": null, "notes": ["Walk-in appointments are now available."], "active": null, "source": {"source": "arcgis", "id": "cbdadf08-4e7d-4946-b730-bc5db81cae77", "fetched_from_uri": "https://experience.arcgis.com/experience/24159814f1dd4f69b6c22e7e87bca65b", "fetched_at": "2021-04-28T14:08:28.675763", "published_at": null, "data": {"attributes": {"FQHC_Registry_Stat": null, "GlobalID": "cbdadf08-4e7d-4946-b730-bc5db81cae77", "ID": "ISDH932", "IsView": 1, "Name": "Adams Memorial Hospital", "OBJECTID": 1, "Promote_Name": null, "Promote_Site": null, "Site_Address": "1100 Mercer Ave, Decatur, IN 46733", "Site_County": "Adams", "Site_Location_Info": null, "Site_Name": "ADAMS MEMORIAL HOSPITAL VAX", "Site_Phone": null, "Site_Special_Inst": "Walk-in appointments are now available.", "Site_Type": "Hospital", "Site_Zotec_Link": "https://vaccine.coronavirus.in.gov", "Symbology": "Regular", "Vaccine_Type": "Moderna"}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -84.91267832291557, "y": 40.81772566014207}}}}
{"id": "in:arcgis:46630b2520ce44a68a9f42f8343d3518_0:1ed530e1-aa21-402b-969a-3272527a8228", "name": "Ascension St. Vincent Noblesville", "address": {"street1": "9460 E 146th St", "street2": "Noblesville", "city": "Noblesville", "state": "IN", "zip": "46060-4966"}, "location": {"latitude": 40.000914359338374, "longitude": -86.00056525122442}, "contact": [{"contact_type": null, "phone": null, "website": "https://vaccine.coronavirus.in.gov", "email": null, "other": null}], "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": [{"vaccine": "pfizer_biontech", "supply_level": null}], "access": null, "parent_organization": null, "links": null, "notes": ["Walk-in appointments are now available."], "active": null, "source": {"source": "arcgis", "id": "1ed530e1-aa21-402b-969a-3272527a8228", "fetched_from_uri": "https://experience.arcgis.com/experience/24159814f1dd4f69b6c22e7e87bca65b", "fetched_at": "2021-04-28T14:08:28.675763", "published_at": null, "data": {"attributes": {"FQHC_Registry_Stat": null, "GlobalID": "1ed530e1-aa21-402b-969a-3272527a8228", "ID": "ISDH949", "IsView": 1, "Name": "Ascension St. Vincent Noblesville", "OBJECTID": 2, "Promote_Name": null, "Promote_Site": null, "Site_Address": "9460 E 146th St, Noblesville, IN\u00a0 46060-4966", "Site_County": "Hamilton", "Site_Location_Info": null, "Site_Name": "ASCENSION ST VINCENT NBLSVILLE VAX", "Site_Phone": null, "Site_Special_Inst": "Walk-in appointments are now available.", "Site_Type": "Hospital", "Site_Zotec_Link": "https://vaccine.coronavirus.in.gov", "Symbology": "Regular", "Vaccine_Type": "Pfizer"}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -86.00056525122442, "y": 40.000914359338374}}}}
{"id": "in:arcgis:46630b2520ce44a68a9f42f8343d3518_0:ccfa4ce8-ada2-4a5e-96e7-8da8d0a98d9d", "name": "Ascension St. Vincent Evansville", "address": {"street1": "3700 Washington Ave", "street2": "Evansville", "city": "Evansville", "state": "IN", "zip": "47714"}, "location": {"latitude": 37.962649899242535, "longitude": -87.50345150328864}, "contact": [{"contact_type": null, "phone": null, "website": "https://vaccine.coronavirus.in.gov", "email": null, "other": null}, {"contact_type": null, "phone": null, "website": null, "email": null, "other": "Manor Building-Auditorium, across from the ER. Parking on 3rd and 4th floor of auditorium parking garage."}], "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": [{"vaccine": "pfizer_biontech", "supply_level": null}], "access": null, "parent_organization": null, "links": null, "notes": ["Walk-in appointments are now available.", "Manor Building-Auditorium, across from the ER. Parking on 3rd and 4th floor of auditorium parking garage."], "active": null, "source": {"source": "arcgis", "id": "ccfa4ce8-ada2-4a5e-96e7-8da8d0a98d9d", "fetched_from_uri": "https://experience.arcgis.com/experience/24159814f1dd4f69b6c22e7e87bca65b", "fetched_at": "2021-04-28T14:08:28.675763", "published_at": null, "data": {"attributes": {"FQHC_Registry_Stat": null, "GlobalID": "ccfa4ce8-ada2-4a5e-96e7-8da8d0a98d9d", "ID": "ISDH980", "IsView": 1, "Name": "Ascension St. Vincent Evansville", "OBJECTID": 3, "Promote_Name": "ASCENSION ST VINCENT EVANSVILLE VAX - <a href=\"https://vaccine.coronavirus.in.gov\" target=\"_blank\">Search Zip Code 47714</a>", "Promote_Site": "Y", "Site_Address": "3700 Washington Ave, Evansville, IN 47714", "Site_County": "Vanderburgh", "Site_Location_Info": "Manor Building-Auditorium, across from the ER. Parking on 3rd and 4th floor of auditorium parking garage.", "Site_Name": "ASCENSION ST VINCENT EVANSVILL VAX", "Site_Phone": null, "Site_Special_Inst": "Walk-in appointments are now available.", "Site_Type": "Hospital", "Site_Zotec_Link": "https://vaccine.coronavirus.in.gov", "Symbology": "Regular", "Vaccine_Type": "Pfizer"}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -87.50345150328864, "y": 37.962649899242535}}}}
{"id": "in:arcgis:46630b2520ce44a68a9f42f8343d3518_0:287b223f-f73e-4e37-9f5f-4569d0834aa2", "name": "Ascension St. Vincent Kokomo", "address": {"street1": "615 St Joseph Dr", "street2": "Kokomo", "city": "Kokomo", "state": "IN", "zip": "46901"}, "location": {"latitude": 40.490813496010574, "longitude": -86.16184526043091}, "contact": [{"contact_type": null, "phone": null, "website": "https://vaccine.coronavirus.in.gov", "email": null, "other": null}], "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": [{"vaccine": "pfizer_biontech", "supply_level": null}], "access": null, "parent_organization": null, "links": null, "notes": ["Walk-in appointments are now available."], "active": null, "source": {"source": "arcgis", "id": "287b223f-f73e-4e37-9f5f-4569d0834aa2", "fetched_from_uri": "https://experience.arcgis.com/experience/24159814f1dd4f69b6c22e7e87bca65b", "fetched_at": "2021-04-28T14:08:28.675763", "published_at": null, "data": {"attributes": {"FQHC_Registry_Stat": null, "GlobalID": "287b223f-f73e-4e37-9f5f-4569d0834aa2", "ID": "ISDH954", "IsView": 1, "Name": "Ascension St. Vincent Kokomo", "OBJECTID": 4, "Promote_Name": null, "Promote_Site": null, "Site_Address": "615 St Joseph Dr, Kokomo, IN\u00a0 46901", "Site_County": "Howard", "Site_Location_Info": null, "Site_Name": "ST V KOKOMO EDUCATION CENTER VAX", "Site_Phone": null, "Site_Special_Inst": "Walk-in appointments are now available.", "Site_Type": "Hospital", "Site_Zotec_Link": "https://vaccine.coronavirus.in.gov", "Symbology": "Regular", "Vaccine_Type": "Pfizer"}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -86.16184526043091, "y": 40.490813496010574}}}}
{"id": "in:arcgis:46630b2520ce44a68a9f42f8343d3518_0:a2f65d89-9403-499d-8840-dda7a3d362aa", "name": "Baptist Health Floyd", "address": {"street1": "1850 State St", "street2": "New Albany", "city": "New Albany", "state": "IN", "zip": "47150"}, "location": {"latitude": 38.30050661300315, "longitude": -85.83441045328028}, "contact": [{"contact_type": null, "phone": null, "website": "https://vaccine.coronavirus.in.gov", "email": null, "other": null}, {"contact_type": null, "phone": null, "website": null, "email": null, "other": "Clinic will use old\u00a0emergency department ambulance bay off of State Street, on north side of the building. "}], "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": [{"vaccine": "pfizer_biontech", "supply_level": null}], "access": null, "parent_organization": null, "links": null, "notes": ["Walk-in appointments are now available.", "Clinic will use old\u00a0emergency department ambulance bay off of State Street, on north side of the building. "], "active": null, "source": {"source": "arcgis", "id": "a2f65d89-9403-499d-8840-dda7a3d362aa", "fetched_from_uri": "https://experience.arcgis.com/experience/24159814f1dd4f69b6c22e7e87bca65b", "fetched_at": "2021-04-28T14:08:28.675763", "published_at": null, "data": {"attributes": {"FQHC_Registry_Stat": null, "GlobalID": "a2f65d89-9403-499d-8840-dda7a3d362aa", "ID": "ISDH947", "IsView": 1, "Name": "Baptist Health Floyd", "OBJECTID": 5, "Promote_Name": "BAPTIST HEALTH FLOYD VAX - <a href=\"https://vaccine.coronavirus.in.gov\" target=\"_blank\">Search Zip Code 47150</a>", "Promote_Site": "Y", "Site_Address": "1850 State St, New Albany, IN 47150", "Site_County": "Floyd", "Site_Location_Info": "Clinic will use old\u00a0emergency department ambulance bay off of State Street, on north side of the building. ", "Site_Name": "BAPTIST HEALTH FLOYD VAX", "Site_Phone": null, "Site_Special_Inst": "Walk-in appointments are now available.", "Site_Type": "Hospital", "Site_Zotec_Link": "https://vaccine.coronavirus.in.gov", "Symbology": "Regular", "Vaccine_Type": "Pfizer"}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -85.83441045328028, "y": 38.30050661300315}}}}
{"id": "in:arcgis:46630b2520ce44a68a9f42f8343d3518_0:e2d8e4cc-cca9-414c-896c-b79f9be80a25", "name": "Beacon (Elkhart General)", "address": {"street1": "1215 Lawn Ave", "street2": "Elkhart", "city": "Elkhart", "state": "IN", "zip": "46514"}, "location": {"latitude": 41.68047068129498, "longitude": -85.99396827889939}, "contact": [{"contact_type": null, "phone": null, "website": "https://vaccine.coronavirus.in.gov", "email": null, "other": null}], "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": [{"vaccine": "pfizer_biontech", "supply_level": null}], "access": null, "parent_organization": null, "links": null, "notes": ["Walk-in appointments are now available."], "active": null, "source": {"source": "arcgis", "id": "e2d8e4cc-cca9-414c-896c-b79f9be80a25", "fetched_from_uri": "https://experience.arcgis.com/experience/24159814f1dd4f69b6c22e7e87bca65b", "fetched_at": "2021-04-28T14:08:28.675763", "published_at": null, "data": {"attributes": {"FQHC_Registry_Stat": null, "GlobalID": "e2d8e4cc-cca9-414c-896c-b79f9be80a25", "ID": "ISDH945", "IsView": 1, "Name": "Beacon (Elkhart General)", "OBJECTID": 6, "Promote_Name": null, "Promote_Site": null, "Site_Address": "1215 Lawn Ave, Elkhart, IN 46514", "Site_County": "Elkhart", "Site_Location_Info": null, "Site_Name": "BEACON ELKHART GENERAL VAX", "Site_Phone": null, "Site_Special_Inst": "Walk-in appointments are now available.", "Site_Type": "Hospital", "Site_Zotec_Link": "https://vaccine.coronavirus.in.gov", "Symbology": "Regular", "Vaccine_Type": "Pfizer"}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -85.99396827889939, "y": 41.68047068129498}}}}
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
