### PR TITLE
Added fetch ny/northwell_health

### DIFF
--- a/vaccine_feed_ingest/runners/ny/northwell_health/fetch.py
+++ b/vaccine_feed_ingest/runners/ny/northwell_health/fetch.py
@@ -6,6 +6,7 @@ import sys
 
 import requests
 
+base_url = "https://api.northwell.edu/"
 url = "https://api.northwell.edu/v2/vax-locations/all"
 
 
@@ -16,7 +17,7 @@ def get_paginated_urls():
 
 
 def get_locations(page_url):
-    response = requests.get(url)
+    response = requests.get(base_url + page_url)
     data = response.json()
     return data["response"]["locations"]
 

--- a/vaccine_feed_ingest/runners/ny/northwell_health/fetch.py
+++ b/vaccine_feed_ingest/runners/ny/northwell_health/fetch.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import sys
+
+import requests
+
+url = "https://api.northwell.edu/v2/vax-locations/all"
+
+
+def get_paginated_urls():
+    response = requests.get(url)
+    data = response.json()
+    return [page_url["url"] for page_url in data["response"]["pagination"]["display"]]
+
+
+def get_locations(page_url):
+    response = requests.get(url)
+    data = response.json()
+    return data["response"]["locations"]
+
+
+def main():
+    output_dir = sys.argv[1]
+    if output_dir is None:
+        print("Must pass an output_dir as first argument")
+
+    page_urls = get_paginated_urls()
+    for index, page_url in enumerate(page_urls):
+        locations = get_locations(page_url)
+        output_file_path = os.path.join(output_dir, f"output{index}.json")
+        with open(output_file_path, "w", encoding="utf-8") as f:
+            json.dump(locations, f, ensure_ascii=False, indent=4)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# <!-- <stage> <site> for <state> (e.g.,  Normalize ArcGIS for MD) -->

| Key Details |
|-|
| Resolves #317 |
State: ny |
Site: northwell_health |

## Notes

After some digging, I managed to find an API! 😄 

The vaccine locations are paginated. For n pages, n+1 requests are made.

1. GET "https://api.northwell.edu/v2/vax-locations/all" to grab page urls
2. GET "https://api.northwell.edu/v2/vax-locations/all?page=1

&nbsp;&nbsp;&nbsp;n. GET "https://api.northwell.edu/v2/vax-locations/all?page={n}"

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```json
[
    {
        "id": 13,
        "name": "Westchester - Chappaqua Crossing (480 N Bedford Rd) -- Moderna",
        "address": "480 N Bedford Rod",
        "suite": "",
        "city": "Chappaqua",
        "state": "New York",
        "zip": "10514",
        "county": "Westchester",
        "latitude": "41.1789",
        "longitude": "-73.7515",
        "program_url": "https://northwellvaccine.force.com/s/?id=a1T4x000007TWHNEA4",
        "vaccine_manufacturer": "Moderna",
        "distance": null
    },
    {
        "id": 12,
        "name": "Westchester Chappaqua Crossing (480 N Bedford Rd) -- Pfizer",
        "address": "480 N Bedford Rod",
        "suite": "",
        "city": "Chappaqua",
        "state": "New York",
        "zip": "10514",
        "county": "Westchester",
        "latitude": "41.1789",
        "longitude": "-73.7515",
        "program_url": "https://northwellvaccine.force.com/s/?id=a1T4x000007TWHNEA4",
        "vaccine_manufacturer": "Pfizer",
        "distance": null
    }
]
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
