### PR TITLE
Fix ma/vaxfinder and ak/arcgis normalizers.

### DIFF
--- a/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
@@ -49,7 +49,7 @@ def _get_id(site: dict) -> str:
     arcgis = "d92cbd6ff2524d7e92bef109f30cb366"
     layer = 0
 
-    return f"{runner}_{site_name}:{arcgis}_{layer}:{data_id}"
+    return f"{runner}_{site_name}:{arcgis}_{layer}_{data_id}"
 
 
 def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:

--- a/vaccine_feed_ingest/runners/ky/govstatus/normalize.py
+++ b/vaccine_feed_ingest/runners/ky/govstatus/normalize.py
@@ -63,6 +63,7 @@ def _get_contacts(site: dict):
     if "register_phone" in site:
         raw_phone = site["register_phone"]
         if raw_phone:
+            print(raw_phone)
             raw_phone = raw_phone.lstrip("tel:")
             raw_phone = raw_phone.lstrip(" ")
             raw_phone = raw_phone.lstrip("1")
@@ -82,16 +83,7 @@ def _get_contacts(site: dict):
             phone_notes = phone_notes.lstrip(";")
             phone_notes = phone_notes.lstrip(" ")
 
-            if phone_notes:
-                ret.append(
-                    schema.Contact(
-                        phone=phone,
-                        other=f"phone_notes:{phone_notes}",
-                        contact_type="booking",
-                    )
-                )
-            else:
-                ret.append(schema.Contact(phone=phone, contact_type="booking"))
+            ret.append(schema.Contact(phone=phone, contact_type="booking"))
 
     if "register_online_url" in site:
         website = site["register_online_url"]

--- a/vaccine_feed_ingest/runners/ky/govstatus/normalize.py
+++ b/vaccine_feed_ingest/runners/ky/govstatus/normalize.py
@@ -63,7 +63,6 @@ def _get_contacts(site: dict):
     if "register_phone" in site:
         raw_phone = site["register_phone"]
         if raw_phone:
-            print(raw_phone)
             raw_phone = raw_phone.lstrip("tel:")
             raw_phone = raw_phone.lstrip(" ")
             raw_phone = raw_phone.lstrip("1")

--- a/vaccine_feed_ingest/runners/ma/vaxfinder_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ma/vaxfinder_gov/normalize.py
@@ -8,6 +8,10 @@ from hashlib import md5
 
 from vaccine_feed_ingest_schema import location as schema
 
+from vaccine_feed_ingest.utils.normalize import normalize_zip
+
+SOURCE_NAME = "vaxfinder_gov"
+
 
 def _generate_id(unique_str: str) -> str:
     return md5(unique_str.encode("utf-8")).hexdigest()
@@ -25,7 +29,7 @@ def normalize(site: dict, timestamp: str) -> schema.NormalizedLocation:
     address_parts.pop()
     state_zip_parts = [p.strip() for p in state_zip.split(" ")]
 
-    zipcode = state_zip_parts[1]
+    zipcode = normalize_zip(state_zip_parts[1])
     city_or_state = state_zip_parts[0]
 
     # Sometimes, MA is not included in the address, so the first part of this is actually the city
@@ -47,7 +51,7 @@ def normalize(site: dict, timestamp: str) -> schema.NormalizedLocation:
     location_id = _generate_id(name_without_city + address)
 
     return schema.NormalizedLocation(
-        id=location_id,
+        id=f"{SOURCE_NAME}:{location_id}",
         name=name_without_city,
         address=schema.Address(
             street1=street1,
@@ -71,7 +75,7 @@ def normalize(site: dict, timestamp: str) -> schema.NormalizedLocation:
         notes=None,
         active=None,
         source=schema.Source(
-            source="vaxfinder",
+            source=SOURCE_NAME,
             id=location_id,
             fetched_from_uri="https://www.mass.gov/doc/covid-19-vaccine-locations-for-currently-eligible-recipients-csv/download",  # noqa: E501
             fetched_at=timestamp,

--- a/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
@@ -148,7 +148,7 @@ def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
 def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLocation:
     return schema.NormalizedLocation(
         id=_get_id(site),
-        name=site["attributes"]["loc_name"],
+        name=site["attributes"]["loc_name"][:256],
         address=_get_address(site),
         location=schema.LatLng(
             latitude=site["geometry"]["y"],

--- a/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
@@ -145,10 +145,15 @@ def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
     return None
 
 
-def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLocation:
+def _get_normalized_location(
+    site: dict, timestamp: str
+) -> Optional[schema.NormalizedLocation]:
+    if len(site["attributes"]["loc_name"]) > 256:
+        return None
+
     return schema.NormalizedLocation(
         id=_get_id(site),
-        name=site["attributes"]["loc_name"][:256],
+        name=site["attributes"]["loc_name"],
         address=_get_address(site),
         location=schema.LatLng(
             latitude=site["geometry"]["y"],
@@ -196,6 +201,9 @@ for in_filepath in json_filepaths:
                 normalized_site = _get_normalized_location(
                     parsed_site, parsed_at_timestamp
                 )
+
+                if not normalized_site:
+                    continue
 
                 json.dump(normalized_site.dict(), fout)
                 fout.write("\n")

--- a/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
@@ -12,6 +12,8 @@ from typing import List, Optional
 from vaccine_feed_ingest_schema import location as schema
 
 # Configure logger
+from vaccine_feed_ingest.utils.normalize import normalize_zip
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
@@ -46,15 +48,7 @@ def _get_id(site: dict) -> str:
 # This currently tosses any address if it doesn't have a street address or zip because
 # the schema doesn't allow optionals for those
 def _get_address(site: dict) -> Optional[schema.Address]:
-    ZIP_RE = re.compile(r"([0-9]{5})([0-9]{4})")
-    zipc = site["attributes"]["SiteZip"]
-
-    if zipc is not None:
-        if ZIP_RE.match(zipc):
-            zipc = ZIP_RE.sub(r"\1-\2", zipc)
-        length = len(zipc)
-        if length != 5 and length != 10:
-            zipc = None
+    zipc = normalize_zip(site["attributes"]["SiteZip"])
 
     return schema.Address(
         street1=site["attributes"]["SiteAddress"],

--- a/vaccine_feed_ingest/utils/normalize.py
+++ b/vaccine_feed_ingest/utils/normalize.py
@@ -38,3 +38,17 @@ def provider_id_from_name(name: str) -> Optional[Tuple[str, str]]:
         return "cvs", str(int(m.group(1)))
 
     return None
+
+
+ZIP_RE = re.compile(r"([0-9]{5})([0-9]{4})")
+
+
+def normalize_zip(zipc: Optional[str]) -> Optional[str]:
+    if zipc is not None:
+        if ZIP_RE.match(zipc):
+            zipc = ZIP_RE.sub(r"\1-\2", zipc)
+        length = len(zipc)
+        if length != 5 and length != 10:
+            zipc = None
+
+    return zipc


### PR DESCRIPTION
Fix schema validation errors for `ma/vaxfinder` and `ak/arcgis`.

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
