### PR TITLE
Standardize logging config

### DIFF
--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -4,7 +4,6 @@
 Entry point for running vaccine feed runners
 """
 import datetime
-import logging
 import os
 import pathlib
 from typing import Callable, Collection, Optional, Sequence
@@ -14,13 +13,6 @@ import dotenv
 import pathy
 
 from .stages import common, ingest, load, site
-
-# Configure logger
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
 
 # Collect locations that are within .6 degrees = 66.6 km = 41 mi
 CANDIDATE_DEGREES_DISTANCE = 0.6

--- a/vaccine_feed_ingest/ingestors/arcgis_ingest.py
+++ b/vaccine_feed_ingest/ingestors/arcgis_ingest.py
@@ -39,7 +39,7 @@ def fetch_geojson(
         results = layer.query(return_all_records=True, out_sr=4326)
         layer_id = layer.properties.id
         file_name = f"{service_item_id}_{layer_id}.json"
-        print(f"Saving {layer.properties.name} layer to {file_name}")
+        logger.info(f"Saving {layer.properties.name} layer to {file_name}")
         results.save(output_dir, file_name)
 
 
@@ -114,7 +114,7 @@ def get_results(
 
     output_file = join(output_dir, f"{offset}.json")
     with open(output_file, "wb") as fh:
-        print(f"Writing {output_file}")
+        logger.info(f"Writing {output_file}")
         fh.write(r.data)
 
 
@@ -124,7 +124,7 @@ def fetch(
     """Fetch ArcGIS features in chunks of batch_size"""
 
     count = get_count(query_url)
-    print(f"Found {count} results")
+    logger.info(f"Found {count} results")
 
     for offset in range(0, count, batch_size):
         get_results(query_url, offset, batch_size, output_dir, format)

--- a/vaccine_feed_ingest/ingestors/arcgis_ingest.py
+++ b/vaccine_feed_ingest/ingestors/arcgis_ingest.py
@@ -1,22 +1,18 @@
 #!/usr/bin/env python3
 
 import json
-import logging
 from os.path import join
 from typing import Optional, Sequence
 
 import urllib3
 from arcgis import GIS
 
+from vaccine_feed_ingest.utils.log import getLogger
+
 http = urllib3.PoolManager()
 
-# Configure logger
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("arcgis")
+
+logger = getLogger(__file__)
 
 
 def fetch_geojson(

--- a/vaccine_feed_ingest/runners/_shared/fetch.py
+++ b/vaccine_feed_ingest/runners/_shared/fetch.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
-import logging
 import pathlib
 import sys
 
 import yaml
+
+from vaccine_feed_ingest.utils.log import getLogger
 
 # import arcgis ingestor
 shared_dir = pathlib.Path(__file__).parent
@@ -14,13 +15,7 @@ sys.path.append(str(root_dir))
 
 from ingestors import arcgis_ingest  # noqa: E402
 
-# Configure logger
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("_shared/fetch.py")
+logger = getLogger(__file__)
 
 output_dir = sys.argv[1]
 yml_config = sys.argv[2]

--- a/vaccine_feed_ingest/runners/_shared/fetch.py
+++ b/vaccine_feed_ingest/runners/_shared/fetch.py
@@ -25,7 +25,7 @@ with open(yml_config, "r") as stream:
     try:
         config = yaml.safe_load(stream)
     except yaml.YAMLError as exc:
-        print(exc)
+        logger.error(exc)
 
 try:
     state = config["state"]

--- a/vaccine_feed_ingest/runners/_shared/parse.py
+++ b/vaccine_feed_ingest/runners/_shared/parse.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import json
-import logging
 import os
 import pathlib
 import sys
@@ -9,13 +8,9 @@ from typing import List
 
 import yaml
 
-# Configure logger
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("_shared/parse.py")
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
 
 OUTPUT_DIR = pathlib.Path(sys.argv[1])
 INPUT_DIR = pathlib.Path(sys.argv[2])

--- a/vaccine_feed_ingest/runners/_shared/parse.py
+++ b/vaccine_feed_ingest/runners/_shared/parse.py
@@ -29,7 +29,7 @@ def _get_config(yml_config: pathlib.Path) -> dict:
         try:
             config = yaml.safe_load(stream)
         except yaml.YAMLError as exc:
-            print(exc)
+            logger.error(exc)
 
     _enforce_keys(config, ["state", "site", "parser"])
 

--- a/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
@@ -2,7 +2,6 @@
 
 import datetime
 import json
-import logging
 import os
 import pathlib
 import re
@@ -11,13 +10,9 @@ from typing import List, Optional
 
 from vaccine_feed_ingest_schema import location as schema
 
-# Configure logger
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("ak/arcgis/normalize.py")
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
 
 
 def _get_availability(site: dict) -> schema.Availability:

--- a/vaccine_feed_ingest/runners/al/jefferson/fetch.py
+++ b/vaccine_feed_ingest/runners/al/jefferson/fetch.py
@@ -7,11 +7,16 @@ import sys
 import requests
 from bs4 import BeautifulSoup
 
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
+
 jcdh_org_url = "https://www.jcdh.org/"
 
 output_dir = sys.argv[1]
 if output_dir is None:
-    print("Must pass an output_dir as first argument")
+    logger.error("Must pass an output_dir as first argument")
+    sys.exit(1)
 
 session = requests.Session()
 response = session.get(jcdh_org_url)

--- a/vaccine_feed_ingest/runners/az/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/az/arcgis/normalize.py
@@ -2,7 +2,7 @@
 # isort: skip_file
 
 import json
-import logging
+from vaccine_feed_ingest.utils.log import getLogger
 import os
 import pathlib
 import re
@@ -14,13 +14,8 @@ from vaccine_feed_ingest_schema import location as schema
 
 from vaccine_feed_ingest.utils.validation import BOUNDING_BOX
 
-# Configure logger
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("az/arcgis/normalize.py")
+
+logger = getLogger(__file__)
 
 output_dir = pathlib.Path(sys.argv[1])
 input_dir = pathlib.Path(sys.argv[2])

--- a/vaccine_feed_ingest/runners/ca/metrolink/normalize.py
+++ b/vaccine_feed_ingest/runners/ca/metrolink/normalize.py
@@ -2,18 +2,14 @@
 
 import datetime
 import json
-import logging
 import pathlib
 import sys
 
 from vaccine_feed_ingest_schema import schema  # noqa: E402
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("ca/metrolink/normalize.py")
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
 
 _source_name = "ca_metrolink"
 

--- a/vaccine_feed_ingest/runners/co/colorado_gov/parse.py
+++ b/vaccine_feed_ingest/runners/co/colorado_gov/parse.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
 
 import json
-import logging
 import pathlib
 import sys
 
 from lxml import etree
 from pykml import parser
 
-logger = logging.getLogger("co/colorado_gov/parse.py")
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
 
 
 def parse_point(element):

--- a/vaccine_feed_ingest/runners/ct/covidvaccinefinder_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ct/covidvaccinefinder_gov/normalize.py
@@ -3,7 +3,7 @@
 
 import datetime
 import json
-import logging
+from vaccine_feed_ingest.utils.log import getLogger
 import pathlib
 import sys
 from typing import Optional
@@ -14,7 +14,7 @@ from vaccine_feed_ingest_schema import location as schema
 from vaccine_feed_ingest.utils.normalize import provider_id_from_name
 from vaccine_feed_ingest.utils.validation import BOUNDING_BOX
 
-logger = logging.getLogger("ct/covidvaccinefinder_gov")
+logger = getLogger(__file__)
 
 
 def _in_bounds(lat_lng: schema.LatLng) -> bool:

--- a/vaccine_feed_ingest/runners/ga/dph/fetch.py
+++ b/vaccine_feed_ingest/runners/ga/dph/fetch.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import asyncio
-import logging
 import pathlib
 import sys
 from typing import List
@@ -10,7 +9,9 @@ from urllib.parse import urljoin
 from aiohttp import ClientSession
 from bs4 import BeautifulSoup
 
-logger = logging.getLogger("ga/dph/fetch.py")
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
 start_url = "https://dph.georgia.gov/locations/covid-vaccination-site"
 
 
@@ -59,6 +60,8 @@ async def fetch_location(
 async def main():
     output_dir = pathlib.Path(sys.argv[1])
     output_file = output_dir / "locations.html"
+
+    logger.info("starting")
 
     async with ClientSession() as session:
         contents = ""

--- a/vaccine_feed_ingest/runners/il/sfsites/fetch.py
+++ b/vaccine_feed_ingest/runners/il/sfsites/fetch.py
@@ -6,8 +6,12 @@ import sys
 
 import requests
 
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
+
 if len(sys.argv) < 2:
-    print("Must pass an output_dir as first argument")
+    logger.error("Must pass an output_dir as first argument")
     sys.exit(1)
 output_dir = sys.argv[1]
 

--- a/vaccine_feed_ingest/runners/in/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/in/arcgis/normalize.py
@@ -2,7 +2,6 @@
 
 import datetime
 import json
-import logging
 import os
 import pathlib
 import re
@@ -11,13 +10,9 @@ from typing import List, Optional
 
 from vaccine_feed_ingest_schema import location as schema
 
-# Configure logger
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("in/arcgis/normalize.py")
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
 
 
 def _get_id(site: dict) -> str:

--- a/vaccine_feed_ingest/runners/ky/govstatus/normalize.py
+++ b/vaccine_feed_ingest/runners/ky/govstatus/normalize.py
@@ -2,20 +2,15 @@
 
 import datetime
 import json
-import logging
 import pathlib
 import sys
 from typing import Optional
 
 from vaccine_feed_ingest_schema import location as schema
 
-# Configure logger
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("ky/govstatus/normalize.py")
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
 
 SOURCE_NAME = "ky_govstatus"
 

--- a/vaccine_feed_ingest/runners/ky/govstatus/parse.py
+++ b/vaccine_feed_ingest/runners/ky/govstatus/parse.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
 
 import json
-import logging
 import pathlib
 import re
 import sys
 
 from bs4 import BeautifulSoup
 
-logger = logging.getLogger("ky/govstatus/parse.py")
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
 
 
 def parse_address(address_el):

--- a/vaccine_feed_ingest/runners/la/tableau/normalize.py
+++ b/vaccine_feed_ingest/runners/la/tableau/normalize.py
@@ -2,7 +2,6 @@
 
 import datetime
 import json
-import logging
 import os
 import pathlib
 import re
@@ -11,15 +10,10 @@ from typing import List, Optional
 
 from vaccine_feed_ingest_schema import location as schema
 
+from vaccine_feed_ingest.utils.log import getLogger
 from vaccine_feed_ingest.utils.normalize import provider_id_from_name
 
-# Configure logger
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("la/tableau/normalize.py")
+logger = getLogger(__file__)
 
 
 def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:

--- a/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
@@ -2,7 +2,6 @@
 
 import datetime
 import json
-import logging
 import pathlib
 import re
 import sys
@@ -10,13 +9,9 @@ from typing import List, Optional
 
 from vaccine_feed_ingest_schema import location as schema
 
-# Configure logger
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("me/maine_gov/normalize.py")
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
 
 
 def _get_name(site: dict) -> str:

--- a/vaccine_feed_ingest/runners/mo/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/mo/arcgis/normalize.py
@@ -2,7 +2,6 @@
 
 import datetime
 import json
-import logging
 import os
 import pathlib
 import re
@@ -11,13 +10,9 @@ from typing import List, Optional
 
 from vaccine_feed_ingest_schema import location as schema
 
-# Configure logger
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("mo/arcgis/normalize.py")
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
 
 
 def _get_id(site: dict) -> str:

--- a/vaccine_feed_ingest/runners/nc/myspot_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/nc/myspot_gov/normalize.py
@@ -2,13 +2,14 @@
 
 import datetime
 import json
-import logging
 import pathlib
 import sys
 
 from vaccine_feed_ingest_schema import location as schema
 
-logger = logging.getLogger(__name__)
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
 
 
 def _get_id(site: dict) -> str:

--- a/vaccine_feed_ingest/runners/ny/am_i_eligible_covid19vaccine_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ny/am_i_eligible_covid19vaccine_gov/normalize.py
@@ -2,13 +2,14 @@
 
 import datetime
 import json
-import logging
 import pathlib
 import re
 import sys
 from typing import List, Optional
 
 from vaccine_feed_ingest_schema import location as schema
+
+from vaccine_feed_ingest.utils.log import getLogger
 
 CITY_RE = re.compile(r"^([\w ]+), NY$")
 # the providerName field smells like it's being parsed from someplace else,
@@ -17,7 +18,7 @@ CITY_RE = re.compile(r"^([\w ]+), NY$")
 # we'll leave that for now.
 NAME_CLEAN_RE = re.compile("^[\u1d42*]+")
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__file__)
 
 
 def _get_inventory(raw: str) -> Optional[List[schema.Vaccine]]:

--- a/vaccine_feed_ingest/runners/ny/northwell_health/fetch.py
+++ b/vaccine_feed_ingest/runners/ny/northwell_health/fetch.py
@@ -25,7 +25,7 @@ def get_locations(page_url):
 def main():
     output_dir = sys.argv[1]
     if output_dir is None:
-        print("Must pass an output_dir as first argument")
+        raise Exception("Must pass an output_dir as first argument")
 
     page_urls = get_paginated_urls()
     for index, page_url in enumerate(page_urls):
@@ -36,4 +36,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/vaccine_feed_ingest/runners/ny/nyc_arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ny/nyc_arcgis/normalize.py
@@ -3,7 +3,7 @@
 
 import datetime
 import json
-import logging
+from vaccine_feed_ingest.utils.log import getLogger
 import os
 import pathlib
 import re
@@ -14,13 +14,8 @@ import pytz
 
 from vaccine_feed_ingest.schema import schema  # noqa: E402
 
-# Configure logger
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("ny/nyc_arcgis/normalize.py")
+
+logger = getLogger(__file__)
 
 utc_tz = pytz.timezone("UTC")
 

--- a/vaccine_feed_ingest/runners/ok/vaccinate_gov/fetch.py
+++ b/vaccine_feed_ingest/runners/ok/vaccinate_gov/fetch.py
@@ -7,12 +7,17 @@ import sys
 import requests
 from bs4 import BeautifulSoup
 
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
+
 csrf_url = "https://vaccinate.oklahoma.gov/_layout/tokenhtml"
 api_url = "https://vaccinate.oklahoma.gov/EntityList/Map/Search/"
 
 output_dir = sys.argv[1]
 if output_dir is None:
-    print("Must pass an output_dir as first argument")
+    logger.error("Must pass an output_dir as first argument")
+    sys.exit(1)
 
 session = requests.Session()
 

--- a/vaccine_feed_ingest/runners/pa/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/pa/arcgis/normalize.py
@@ -2,7 +2,6 @@
 
 import datetime
 import json
-import logging
 import os
 import pathlib
 import re
@@ -11,13 +10,9 @@ from typing import List, Optional
 
 from vaccine_feed_ingest_schema import location as schema
 
-# Configure logger
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("pa/arcgis/normalize.py")
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
 
 
 def _get_id(site: dict) -> str:

--- a/vaccine_feed_ingest/runners/ri/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ri/arcgis/normalize.py
@@ -2,7 +2,6 @@
 
 import datetime
 import json
-import logging
 import os
 import pathlib
 import re
@@ -11,13 +10,9 @@ from typing import List, Optional
 
 from vaccine_feed_ingest_schema import location as schema
 
-# Configure logger
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("ri/arcgis/normalize.py")
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
 
 
 def _get_id(site: dict) -> str:

--- a/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
@@ -2,7 +2,6 @@
 
 import datetime
 import json
-import logging
 import os
 import pathlib
 import re
@@ -11,15 +10,10 @@ from typing import List, Optional
 
 from vaccine_feed_ingest_schema import location as schema
 
-# Configure logger
+from vaccine_feed_ingest.utils.log import getLogger
 from vaccine_feed_ingest.utils.normalize import normalize_zip
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-    datefmt="%m/%d/%Y %H:%M:%S",
-)
-logger = logging.getLogger("sc/arcgis/normalize.py")
+logger = getLogger(__file__)
 
 output_dir = pathlib.Path(sys.argv[1])
 input_dir = pathlib.Path(sys.argv[2])

--- a/vaccine_feed_ingest/runners/us/vaccinespotter_org/normalize.py
+++ b/vaccine_feed_ingest/runners/us/vaccinespotter_org/normalize.py
@@ -3,7 +3,7 @@
 
 import datetime
 import json
-import logging
+from vaccine_feed_ingest.utils.log import getLogger
 import pathlib
 import sys
 from typing import Optional
@@ -14,7 +14,7 @@ from vaccine_feed_ingest_schema import location as schema
 from vaccine_feed_ingest.utils.normalize import provider_id_from_name
 from vaccine_feed_ingest.utils.validation import BOUNDING_BOX
 
-logger = logging.getLogger("us/vaccinespotter_org")
+logger = getLogger(__file__)
 
 
 def _get_address(site: dict) -> Optional[schema.Address]:

--- a/vaccine_feed_ingest/runners/wa/prepmod/fetch.py
+++ b/vaccine_feed_ingest/runners/wa/prepmod/fetch.py
@@ -5,11 +5,16 @@ import sys
 
 import requests
 
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
+
 base_url = "https://prepmod.doh.wa.gov/clinic/search"
 
 output_dir = sys.argv[1]
 if output_dir is None:
-    print("Must pass an output_dir as first argument")
+    logger.error("Must pass an output_dir as first argument")
+    sys.exit(1)
 
 page = 1
 while True:

--- a/vaccine_feed_ingest/runners/wi/arcgis_map/fetch.py
+++ b/vaccine_feed_ingest/runners/wi/arcgis_map/fetch.py
@@ -4,12 +4,17 @@ import sys
 
 from arcgis.features import FeatureLayer
 
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
+
 url = "https://dhsgis.wi.gov/server/rest/services/DHS_COVID19/COVID19_Vaccine_Provider_Sites/MapServer/0"
 
 
 output_dir = sys.argv[1]
 if output_dir is None:
-    print("Must pass an output_dir as first argument")
+    logger.error("Must pass an output_dir as first argument")
+    sys.exit(1)
 
 layer = FeatureLayer(url)
 results = layer.query(return_all_records=True)

--- a/vaccine_feed_ingest/stages/enrichment.py
+++ b/vaccine_feed_ingest/stages/enrichment.py
@@ -1,14 +1,15 @@
 """Method for enriching location records after that are normalized"""
-import logging
 import pathlib
 
 import pydantic
 from vaccine_feed_ingest_schema import location
 
+from vaccine_feed_ingest.utils.log import getLogger
+
 from . import outputs
 from .common import STAGE_OUTPUT_SUFFIX, PipelineStage
 
-logger = logging.getLogger("enrichment")
+logger = getLogger(__file__)
 
 
 def enrich_locations(input_dir: pathlib.Path, output_dir: pathlib.Path) -> bool:

--- a/vaccine_feed_ingest/stages/ingest.py
+++ b/vaccine_feed_ingest/stages/ingest.py
@@ -1,7 +1,6 @@
 """Code for running ingestion stage"""
 
 import json
-import logging
 import pathlib
 import subprocess
 import tempfile
@@ -9,11 +8,13 @@ import tempfile
 import pydantic
 from vaccine_feed_ingest_schema import location
 
+from vaccine_feed_ingest.utils.log import getLogger
+
 from ..utils.validation import VACCINATE_THE_STATES_BOUNDARY
 from . import enrichment, outputs, site
 from .common import STAGE_OUTPUT_SUFFIX, PipelineStage
 
-logger = logging.getLogger("ingest")
+logger = getLogger(__file__)
 
 
 def run_fetch(

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -1,4 +1,3 @@
-import logging
 import pathlib
 from typing import Iterable, Iterator, List, Optional
 
@@ -10,12 +9,14 @@ import urllib3
 import us
 from vaccine_feed_ingest_schema import load, location
 
+from vaccine_feed_ingest.utils.log import getLogger
+
 from .. import vial
 from ..utils.match import canonicalize_address, get_full_address
 from . import outputs
 from .common import STAGE_OUTPUT_SUFFIX, PipelineStage
 
-logger = logging.getLogger("load")
+logger = getLogger(__file__)
 
 
 def load_sites_to_vial(

--- a/vaccine_feed_ingest/stages/site.py
+++ b/vaccine_feed_ingest/stages/site.py
@@ -1,13 +1,14 @@
 """Helper methods for finding code and configs for each site"""
 
-import logging
 import os
 import pathlib
 from typing import Iterator, Optional, Sequence, Tuple
 
+from vaccine_feed_ingest.utils.log import getLogger
+
 from .common import RUNNERS_DIR, STAGE_CMD_NAME, PipelineStage
 
-logger = logging.getLogger("ingest")
+logger = getLogger(__file__)
 
 
 def get_site_dirs_for_state(state: Optional[str] = None) -> Iterator[pathlib.Path]:

--- a/vaccine_feed_ingest/utils/log.py
+++ b/vaccine_feed_ingest/utils/log.py
@@ -1,0 +1,36 @@
+import logging
+import pathlib
+from logging import Logger
+
+LOG_FORMAT = "%(asctime)s %(levelname)s:%(name)s:%(message)s"
+# Use RFC-3339 for consistency
+DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+LOG_LEVEL = logging.INFO
+
+root_logger = logging.getLogger()
+root_logger.setLevel(LOG_LEVEL)
+
+utils_dir = pathlib.Path(__file__).parent
+root_dir = utils_dir.parent
+
+
+def getLogger(file_path: str) -> Logger:
+    """
+    Returns a configured logger for the given the module `__file__`
+
+    Example usage:
+
+    ```python
+    from vaccine_feed_ingest.utils.log import getLogger
+
+    logger = getLogger(__file__)
+    ```
+    """
+    relative_path = pathlib.Path(file_path).relative_to(root_dir)
+    logger = logging.getLogger(str(relative_path))
+
+    console_handler = logging.StreamHandler()
+    formatter = logging.Formatter(LOG_FORMAT, DATE_FORMAT)
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+    return logger

--- a/vaccine_feed_ingest/vial.py
+++ b/vaccine_feed_ingest/vial.py
@@ -2,7 +2,6 @@
 
 import contextlib
 import json
-import logging
 import urllib.parse
 from typing import Any, Iterable, Iterator, Tuple
 
@@ -12,9 +11,11 @@ import shapely.geometry
 import urllib3
 from vaccine_feed_ingest_schema import load
 
+from vaccine_feed_ingest.utils.log import getLogger
+
 from .utils import misc
 
-logger = logging.getLogger("vial")
+logger = getLogger(__file__)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
# Standardize logging config

While working on https://github.com/CAVaccineInventory/vaccine-feed-ingest/pull/309 I realized that many loggers were missing configuration for log level and format. To make this consistent across the project, I've abstracted logging config to a utility module.

## Notes

Thanks for you patience reviewing this large PR 🙂
<!-- Share any information which would be helpful to the reviewer -->

## Data sample

A sample of logging output from running `poetry run vaccine-feed-ingest fetch`

```
2021-05-01T16:33:01-0400 INFO:stages/ingest.py:Fetching md/arcgis and saving fetched output to /tmp/tmp3a9lww1q_fetch_md_arcgis/output
2021-05-01T16:33:03-0400 INFO:runners/_shared/fetch.py:Scraping MD/arcgis into output_dir=/tmp/tmp3a9lww1q_fetch_md_arcgis/output, with config from /home/graham/dev/github.com/CAVaccineInventory/vaccine-feed-ingest/vaccine_feed_ingest/runners/md/arcgis/fetch.yml
2021-05-01T16:33:06-0400 INFO:ingestors/arcgis_ingest.py:Saving Mass Vaccination Sites layer to d677f143334648a1a40b84d94df8e134_0.json
2021-05-01T16:33:07-0400 INFO:ingestors/arcgis_ingest.py:Saving Pharmacy Vaccination Sites layer to d677f143334648a1a40b84d94df8e134_1.json
2021-05-01T16:33:07-0400 INFO:ingestors/arcgis_ingest.py:Saving Local Health Department Vaccination Sites layer to d677f143334648a1a40b84d94df8e134_2.json
2021-05-01T16:33:07-0400 INFO:ingestors/arcgis_ingest.py:Saving Hospital Vaccination Sites layer to d677f143334648a1a40b84d94df8e134_3.json
2021-05-01T16:33:08-0400 INFO:ingestors/arcgis_ingest.py:Saving All Maryland Vaccination Sites layer to d677f143334648a1a40b84d94df8e134_4.json
2021-05-01T16:33:08-0400 INFO:stages/ingest.py:Copying files from /tmp/tmp3a9lww1q_fetch_md_arcgis/output to out/md/arcgis/raw/2021-05-01T16:30:09
```

## Before Opening a PR
- [x] I tested this using the CLI
   ```
   poetry run vaccine-feed-ingest fetch
   ```
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
