### PR TITLE
Fix normalize for arcgis for AK

### DIFF
--- a/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ak/arcgis/normalize.py
@@ -49,7 +49,7 @@ def _get_id(site: dict) -> str:
     arcgis = "d92cbd6ff2524d7e92bef109f30cb366"
     layer = 0
 
-    return f"{runner}_{site_name}:{arcgis}_{layer}:{data_id}"
+    return f"{runner}_{site_name}:{arcgis}_{layer}_{data_id}"
 
 
 def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:


### PR DESCRIPTION
# Fix normalize for arcgis for AK

| Key Details |
|-|
State: AK |
Site: arcgis |

## Notes
<!-- Share any information which would be helpful to the reviewer -->

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```json
{"id": "ak_arcgis:d92cbd6ff2524d7e92bef109f30cb366_0_85b07ac7-c9b6-4d09-83ec-a720998c2fbf", "name": "North Slope Borough Public Health Nursing-Wellness", "address": {"street1": "579 Kongosak St", "street2": null, "city": "Barrow", "state": "AK", "zip": "99723"}, "location": {"latitude": 71.29069998454801, "longitude": -156.7920099649541}, "contact": [{"contact_type": null, "phone": "(907) 852-0270", "website": null, "email": null, "other": null}], "languages": null, "opening_dates": null, "opening_hours": null, "availability": {"drop_in": null, "appointments": true}, "inventory": [{"vaccine": "pfizer_biontech", "supply_level": null}], "access": null, "parent_organization": null, "links": null, "notes": ["NSB PHN Wellness clinic, please call for appointments 907-852-0270"], "active": null, "source": {"source": "ak_arcgis", "id": "85b07ac7-c9b6-4d09-83ec-a720998c2fbf", "fetched_from_uri": "https://services1.arcgis.com/WzFsmainVTuD5KML/ArcGIS/rest/services/COVID19_Vaccine_Site_Survey_API/FeatureServer/0", "fetched_at": "2021-05-01T21:27:56.436759", "published_at": "2020-12-25T16:00:00", "data": {"attributes": {"address": "579 Kongosak St", "city": "Barrow", "cost_other": null, "datesubmited": 1608930000000, "flu_acceptsInsurance": "yes_please_contact_your_insuran", "flu_cost": "no_cost", "flu_vaccinations": "pfizer", "flu_walkins": "no_please_make_an_appointment", "globalid": "85b07ac7-c9b6-4d09-83ec-a720998c2fbf", "needs_review": "approved", "objectid": 9, "phone": "907-852-0270", "publicEmail": null, "publicNotes": "NSB PHN Wellness clinic, please call for appointments 907-852-0270", "publicWebsite": null, "vaccinationSite": "North Slope Borough Public Health Nursing-Wellness", "zipcode": "99723"}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -156.7920099649541, "y": 71.29069998454801}}}}
{"id": "ak_arcgis:d92cbd6ff2524d7e92bef109f30cb366_0_0ed786e2-f009-4919-803a-8addbea8f9bd", "name": "Norton Sound Health Corporation", "address": {"street1": "228 Greg Kruschek Ave", "street2": null, "city": "Nome", "state": "AK", "zip": "99762"}, "location": {"latitude": 64.49934297442883, "longitude": -165.3783630383781}, "contact": [{"contact_type": null, "phone": "(907) 434-0461", "website": null, "email": null, "other": null}, {"contact_type": null, "phone": null, "website": null, "email": "pharmacyrx@nshcorp.org", "other": null}, {"contact_type": null, "phone": null, "website": "https://www.picktime.com/NSHC", "email": null, "other": null}], "languages": null, "opening_dates": null, "opening_hours": null, "availability": {"drop_in": null, "appointments": true}, "inventory": [{"vaccine": "moderna", "supply_level": null}, {"vaccine": "pfizer_biontech", "supply_level": null}], "access": null, "parent_organization": null, "links": null, "notes": ["Open 9 AM -6 PM Monday through Friday, 10 AM - 2PM Saturday."], "active": null, "source": {"source": "ak_arcgis", "id": "0ed786e2-f009-4919-803a-8addbea8f9bd", "fetched_from_uri": "https://services1.arcgis.com/WzFsmainVTuD5KML/ArcGIS/rest/services/COVID19_Vaccine_Site_Survey_API/FeatureServer/0", "fetched_at": "2021-05-01T21:27:56.436759", "published_at": "2020-12-26T16:00:00", "data": {"attributes": {"address": "228 Greg Kruschek Ave", "city": "Nome", "cost_other": null, "datesubmited": 1609016400000, "flu_acceptsInsurance": "no", "flu_cost": "no_cost", "flu_vaccinations": "moderna,pfizer", "flu_walkins": "no_please_make_an_appointment", "globalid": "0ed786e2-f009-4919-803a-8addbea8f9bd", "needs_review": "approved", "objectid": 10, "phone": "907-434-0461", "publicEmail": "pharmacyrx@nshcorp.org", "publicNotes": "Open 9 AM -6 PM Monday through Friday, 10 AM - 2PM Saturday.", "publicWebsite": "https://www.picktime.com/NSHC", "vaccinationSite": "Norton Sound Health Corporation", "zipcode": "99762"}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -165.3783630383781, "y": 64.49934297442883}}}}
{"id": "ak_arcgis:d92cbd6ff2524d7e92bef109f30cb366_0_7840e505-ff68-4400-8381-eb67954c43c6", "name": "Soldotna Professional Pharmacy", "address": {"street1": "299 N Binkley St", "street2": null, "city": "Soldotna", "state": "AK", "zip": "99669"}, "location": {"latitude": 60.49456000351094, "longitude": -151.07297003784822}, "contact": [{"contact_type": null, "phone": "(907) 262-3800", "website": null, "email": null, "other": null}, {"contact_type": null, "phone": null, "website": "https://cw2-alaska-production.herokuapp.com/clinic/search", "email": null, "other": null}], "languages": null, "opening_dates": null, "opening_hours": null, "availability": {"drop_in": null, "appointments": true}, "inventory": [{"vaccine": "moderna", "supply_level": null}, {"vaccine": "pfizer_biontech", "supply_level": null}], "access": null, "parent_organization": null, "links": null, "notes": null, "active": null, "source": {"source": "ak_arcgis", "id": "7840e505-ff68-4400-8381-eb67954c43c6", "fetched_from_uri": "https://services1.arcgis.com/WzFsmainVTuD5KML/ArcGIS/rest/services/COVID19_Vaccine_Site_Survey_API/FeatureServer/0", "fetched_at": "2021-05-01T21:27:56.436759", "published_at": "2020-12-27T16:00:00", "data": {"attributes": {"address": "299 N Binkley St", "city": "Soldotna", "cost_other": null, "datesubmited": 1609102800000, "flu_acceptsInsurance": "yes_please_contact_your_insuran", "flu_cost": "no_cost", "flu_vaccinations": "moderna,pfizer", "flu_walkins": "no_please_make_an_appointment", "globalid": "7840e505-ff68-4400-8381-eb67954c43c6", "needs_review": "approved", "objectid": 11, "phone": "907-262-3800", "publicEmail": null, "publicNotes": null, "publicWebsite": "https://cw2-alaska-production.herokuapp.com/clinic/search", "vaccinationSite": "Soldotna Professional Pharmacy", "zipcode": "99669"}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -151.07297003784822, "y": 60.49456000351094}}}}
```

## Before Opening a PR
- [x] I tested this using the CLI
   ```
   poetry run vaccine-feed-ingest fetch ak/arcgis
   poetry run vaccine-feed-ingest parse ak/arcgis
   poetry run vaccine-feed-ingest normalize ak/arcgis
   ```
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
