### PR TITLE
Option to override match and create ids when loading

### DIFF
--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -7,7 +7,7 @@ import datetime
 import logging
 import os
 import pathlib
-from typing import Callable, Collection, Optional, Sequence
+from typing import Callable, Collection, Dict, Optional, Sequence
 
 import click
 import dotenv
@@ -118,6 +118,36 @@ def _create_option() -> Callable:
         "enable_create",
         type=bool,
         default=lambda: os.environ.get("ENABLE_CREATE", "false").lower() == "true",
+    )
+
+
+def _match_ids_option() -> Callable:
+    return click.option(
+        "--match-ids",
+        "match_ids",
+        type=str,
+        callback=lambda ctx, param, value: (
+            dict(
+                [
+                    tuple([v.strip() for v in pair.split("=", maxsplit=1)])
+                    for pair in [item.strip() for item in value.split(",") if item]
+                    if pair and '=' in pair
+                ]
+            )
+            if value else None
+        ),
+    )
+
+
+def _create_ids_option() -> Callable:
+    return click.option(
+        "--create-ids",
+        "create_ids",
+        type=str,
+        callback=lambda ctx, param, value: (
+            [item.strip() for item in value.split(",")]
+            if value else None
+        ),
     )
 
 
@@ -282,6 +312,8 @@ def enrich(
 @_vial_apikey_option()
 @_match_option()
 @_create_option()
+@_match_ids_option()
+@_create_ids_option()
 @_candidate_distance_option()
 def load_to_vial(
     sites: Optional[Sequence[str]],
@@ -292,20 +324,31 @@ def load_to_vial(
     vial_apikey: str,
     enable_match: bool,
     enable_create: bool,
+    match_ids: Optional[Dict[str, str]],
+    create_ids: Optional[Collection[str]],
     candidate_distance: float,
 ) -> None:
     """Load specified sites to vial server."""
     site_dirs = site.get_site_dirs(state, sites)
 
+    if match_ids and create_ids:
+        conflicting_ids = set(match_ids.keys()) & set(create_ids)
+        if conflicting_ids:
+            raise Exception(
+                f"Conflicting match and create action for source ids: {conflicting_ids}"
+            )
+
     load.load_sites_to_vial(
         site_dirs,
         output_dir,
-        dry_run,
-        vial_server,
-        vial_apikey,
-        enable_match,
-        enable_create,
-        candidate_distance,
+        dry_run=dry_run,
+        vial_server=vial_server,
+        vial_apikey=vial_apikey,
+        enable_match=enable_match,
+        enable_create=enable_create,
+        match_ids=match_ids,
+        create_ids=create_ids,
+        candidate_distance=candidate_distance,
     )
 
 
@@ -319,6 +362,8 @@ def load_to_vial(
 @_vial_apikey_option()
 @_match_option()
 @_create_option()
+@_match_ids_option()
+@_create_ids_option()
 @_candidate_distance_option()
 def pipeline(
     sites: Optional[Sequence[str]],
@@ -330,6 +375,8 @@ def pipeline(
     vial_apikey: str,
     enable_match: bool,
     enable_create: bool,
+    match_ids: Optional[Dict[str, str]],
+    create_ids: Optional[Collection[str]],
     candidate_distance: float,
 ) -> None:
     """Run all stages in succession for specified sites."""
@@ -374,6 +421,8 @@ def pipeline(
             vial_apikey=vial_apikey,
             enable_match=enable_match,
             enable_create=enable_create,
+            match_ids=match_ids,
+            create_ids=create_ids,
             candidate_distance=candidate_distance,
         )
 

--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -127,14 +127,16 @@ def _match_ids_option() -> Callable:
         "match_ids",
         type=str,
         callback=lambda ctx, param, value: (
-            dict(
-                [
-                    tuple([v.strip() for v in pair.split("=", maxsplit=1)])
+            {
+                key: value
+                for key, value in [
+                    [v.strip() for v in pair.split("=", maxsplit=1)]
                     for pair in [item.strip() for item in value.split(",") if item]
-                    if pair and '=' in pair
+                    if pair and "=" in pair
                 ]
-            )
-            if value else None
+            }
+            if value
+            else None
         ),
     )
 
@@ -145,8 +147,7 @@ def _create_ids_option() -> Callable:
         "create_ids",
         type=str,
         callback=lambda ctx, param, value: (
-            [item.strip() for item in value.split(",")]
-            if value else None
+            [item.strip() for item in value.split(",")] if value else None
         ),
     )
 

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -1,6 +1,6 @@
 import logging
 import pathlib
-from typing import Iterable, Iterator, List, Optional
+from typing import Collection, Dict, Iterable, Iterator, List, Optional
 
 import jellyfish
 import pydantic
@@ -26,6 +26,8 @@ def load_sites_to_vial(
     vial_apikey: str,
     enable_match: bool,
     enable_create: bool,
+    match_ids: Optional[Dict[str, str]],
+    create_ids: Optional[Collection[str]],
     candidate_distance: float,
 ) -> None:
     """Load list of sites to vial"""
@@ -45,6 +47,8 @@ def load_sites_to_vial(
                 locations=locations,
                 enable_match=enable_match,
                 enable_create=enable_create,
+                match_ids=match_ids,
+                create_ids=create_ids,
                 candidate_distance=candidate_distance,
             )
 
@@ -69,6 +73,8 @@ def run_load_to_vial(
     locations: Optional[rtree.index.Index],
     enable_match: bool = True,
     enable_create: bool = False,
+    match_ids: Optional[Dict[str, str]] = None,
+    create_ids: Optional[Collection[str]] = None,
     candidate_distance: float = 0.6,
 ) -> Optional[List[load.ImportSourceLocation]]:
     """Load source to vial source locations"""
@@ -107,7 +113,16 @@ def run_load_to_vial(
                     continue
 
                 match_action = None
-                if (enable_match or enable_create) and locations is not None:
+                if match_ids and normalized_location.id in match_ids:
+                    match_action = load.ImportMatchAction(
+                        action="existing",
+                        id=match_ids[normalized_location.id],
+                    )
+
+                elif create_ids and normalized_location.id in create_ids:
+                    match_action = load.ImportMatchAction(action="new")
+
+                elif (enable_match or enable_create) and locations is not None:
                     match_action = _match_source_to_existing_locations(
                         normalized_location,
                         locations,


### PR DESCRIPTION
Provide an option with calling `load-to-vial` to manually match or create.

## Match
```
vaccine-feed-ingest load-to-vial ca/sf_gov --match-ids=sf_gov:ocean_park=recKQrT7tv5yoC5r2,sf_gov:safeway_pharmacy_2646=rechVtcpquzPs8Vfg
```

## Create
```
vaccine-feed-ingest load-to-vial ca/sf_gov --create-ids=sf_gov:ocean_park,sf_gov:safeway_pharmacy_2646
```