### PR TITLE
normalize: fix validation errors in wa/prepmod (#345).

### DIFF
--- a/tests/utils/test_provider_id_from_name.py
+++ b/tests/utils/test_provider_id_from_name.py
@@ -1,5 +1,6 @@
 from vaccine_feed_ingest.utils.normalize import provider_id_from_name
 
+
 def test_provider_id_from_name():
     # positive cases
     _test_provider("Rite Aid Pharmacy 3897", "rite_aid", "3897")
@@ -28,6 +29,7 @@ def test_provider_id_from_name():
     # negative cases
     assert provider_id_from_name("garbage") is None
     assert provider_id_from_name("Walblue 232555") is None
+
 
 def _test_provider(input_str, expected_provider_name, expected_provider_id):
     actual_provider_name, actual_provider_id = provider_id_from_name(input_str)

--- a/vaccine_feed_ingest/runners/wa/prepmod/normalize.py
+++ b/vaccine_feed_ingest/runners/wa/prepmod/normalize.py
@@ -14,7 +14,7 @@ from vaccine_feed_ingest_schema import location as schema
 def _get_source(site: dict, timestamp: str) -> schema.Source:
     return schema.Source(
         source="wa_prepmod",
-        id=site["name"],
+        id=site["clinic_id"],
         fetched_from_uri="https://prepmod.doh.wa.gov/clinic/search",
         fetched_at=timestamp,
         data=site,
@@ -89,8 +89,8 @@ def _get_opening_hours(site: dict) -> List[schema.OpenHour]:
 
     return [
         schema.OpenHour(
-            day=calendar.day_name[date_dt.weekday()],
-            open=time_start.strftime("%H:%M"),
+            day=calendar.day_name[date_dt.weekday()].lower(),
+            opens=time_start.strftime("%H:%M"),
             closes=time_end.strftime("%H:%M"),
         )
     ]

--- a/vaccine_feed_ingest/runners/wa/prepmod/parse.py
+++ b/vaccine_feed_ingest/runners/wa/prepmod/parse.py
@@ -2,6 +2,7 @@
 
 import json
 import pathlib
+import re
 import sys
 
 from bs4 import BeautifulSoup
@@ -26,6 +27,9 @@ def find_data_item(parent, label, offset):
         return ""
 
 
+EXTRACT_CLINIC_ID = re.compile(r".*clinic(\d*)\.png")
+
+
 with output_file.open("w") as fout:
     for filename in input_filenames:
         text = open(filename, "r").read()
@@ -43,9 +47,11 @@ with output_file.open("w") as fout:
             hours = find_data_item(parent, "Clinic Hours", -1)
             available_count = find_data_item(parent, "Available Appointments", -1) or 0
             special = find_data_item(parent, "Special Instructions", -1)
-            clinic_id = (
-                parent.find("a")["href"].split("=")[1] if parent.find("a") else None
+
+            find_clinic_id = EXTRACT_CLINIC_ID.match(
+                parent.find_next_sibling("div", "map-image").find("img")["src"]
             )
+            clinic_id = find_clinic_id.group(1)
             data = {
                 "name": name,
                 "date": date,


### PR DESCRIPTION
Resolves #345

Fix validation errors in the wa/prepmod noramlizer. It also required some changes in the parser to get some more reliable IDs.

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
