### PR TITLE
normalize: fix validation errors for ri/arcgis (#344).

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1887,7 +1887,7 @@ doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=5.4.0,<6.0.0)", "markdown-
 
 [[package]]
 name = "typing-extensions"
-version = "3.7.4.3"
+version = "3.10.0.0"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
 optional = false
@@ -1900,6 +1900,17 @@ description = "Ultra fast JSON encoder and decoder for Python"
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "url-normalize"
+version = "1.4.3"
+description = "URL normalization for Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+six = "*"
 
 [[package]]
 name = "urllib3"
@@ -2032,7 +2043,7 @@ test = ["pytest", "pytest-runner"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "4c1c990685e8ceb0d53201da5d7aa8e9e2af47cf4514009699c7379640c4ff77"
+content-hash = "7b9432f2b49cfa7461c8bee6d55125efea6884e03ebfefba0d6472ac382f9459"
 
 [metadata.files]
 aiohttp = [
@@ -3292,9 +3303,9 @@ typer = [
     {file = "typer-0.3.2.tar.gz", hash = "sha256:5455d750122cff96745b0dec87368f56d023725a7ebc9d2e54dd23dc86816303"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
-    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
-    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+    {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
+    {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
+    {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
 ]
 ujson = [
     {file = "ujson-4.0.2-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:e390df0dcc7897ffb98e17eae1f4c442c39c91814c298ad84d935a3c5c7a32fa"},
@@ -3318,6 +3329,10 @@ ujson = [
     {file = "ujson-4.0.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b5c70704962cf93ec6ea3271a47d952b75ae1980d6c56b8496cec2a722075939"},
     {file = "ujson-4.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:aad6d92f4d71e37ea70e966500f1951ecd065edca3a70d3861b37b176dd6702c"},
     {file = "ujson-4.0.2.tar.gz", hash = "sha256:c615a9e9e378a7383b756b7e7a73c38b22aeb8967a8bfbffd4741f7ffd043c4d"},
+]
+url-normalize = [
+    {file = "url-normalize-1.4.3.tar.gz", hash = "sha256:d23d3a070ac52a67b83a1c59a0e68f8608d1cd538783b401bc9de2c0fac999b2"},
+    {file = "url_normalize-1.4.3-py2.py3-none-any.whl", hash = "sha256:ec3c301f04e5bb676d333a7fa162fa977ad2ca04b7e652bfc9fac4e405728eed"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ TableauScraper = "^0.1.11"
 lxml = "^4.6.3"
 pykml = "^0.2.0"
 html5lib = "^1.1"
+url-normalize = "^1.4.3"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.23.0"

--- a/vaccine_feed_ingest/runners/ri/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/ri/arcgis/normalize.py
@@ -11,6 +11,7 @@ from typing import List, Optional
 from vaccine_feed_ingest_schema import location as schema
 
 from vaccine_feed_ingest.utils.log import getLogger
+from vaccine_feed_ingest.utils.normalize import normalize_url
 
 logger = getLogger(__file__)
 
@@ -28,7 +29,7 @@ def _get_id(site: dict) -> str:
     arcgis = "da57e8c8663048a2a9893c636fef63d0"
     layer = 0
 
-    return f"{runner}:{site_name}:{arcgis}_{layer}:{data_id}"
+    return f"{runner}_{site_name}:{arcgis}_{layer}_{data_id}"
 
 
 def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
@@ -42,6 +43,7 @@ def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
         "janssen (johnson & johnson) covid-19 vaccine": schema.Vaccine(
             vaccine="johnson_johnson_janssen"
         ),
+        "varies": None,
     }
 
     inventory = []
@@ -49,7 +51,8 @@ def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
     for vf in vaccines_field:
         try:
             if vf != "-" and vf != "\x08":  # "-" is listed when no data given
-                inventory.append(potentials[vf])
+                if potentials[vf] is not None:
+                    inventory.append(potentials[vf])
         except KeyError as e:
             logger.error("Unexpected vaccine type: %s", e)
 
@@ -70,9 +73,10 @@ def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:
             contacts.append(schema.Contact(phone=phone))
 
     if site["attributes"]["USER_Link_to_Sign_Up"]:
-        contacts.append(
-            schema.Contact(website=site["attributes"]["USER_Link_to_Sign_Up"])
-        )
+        url = site["attributes"]["USER_Link_to_Sign_Up"].strip()
+        if url is not None and url != "\x08" and url != "-":
+            url = normalize_url(url)
+            contacts.append(schema.Contact(website=url))
 
     if len(contacts) > 0:
         return contacts

--- a/vaccine_feed_ingest/utils/normalize.py
+++ b/vaccine_feed_ingest/utils/normalize.py
@@ -4,6 +4,8 @@ Various tricks for matching source locations to product locations from VIAL
 import re
 from typing import Optional, Tuple
 
+import url_normalize
+
 
 def provider_id_from_name(name: str) -> Optional[Tuple[str, str]]:
     """Generate provider ids for retail pharmacies (riteaid:123)"""
@@ -52,3 +54,10 @@ def normalize_zip(zipc: Optional[str]) -> Optional[str]:
             zipc = None
 
     return zipc
+
+
+def normalize_url(url: Optional[str]) -> Optional[str]:
+    if url is None:
+        return url
+
+    return url_normalize.url_normalize(url)


### PR DESCRIPTION
Fix validation errors for ri/arcgis. I also introduced a URL normalizer (in this case, to add the scheme to the URL).

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
