### PR TITLE
Support extraction of ids for more providers (L - Z) found in data

### DIFF
--- a/tests/utils/test_provider_id_from_name.py
+++ b/tests/utils/test_provider_id_from_name.py
@@ -6,8 +6,6 @@ def test_provider_id_from_name():
     # positive cases
     _test_provider("Acme Pharmacy #1058", VaccineProvider.ACME, "1058")
 
-    _test_provider("SAV-ON PHARMACY #585", VaccineProvider.ALBERTSONS, "585")
-    _test_provider("SAVON PHARMACY #585", VaccineProvider.ALBERTSONS, "585")
     _test_provider("Albertsons Pharmacy #1915", VaccineProvider.ALBERTSONS, "1915")
     _test_provider("Albertsons Market Pharmacy #1915", VaccineProvider.ALBERTSONS, "1915")
 
@@ -16,10 +14,12 @@ def test_provider_id_from_name():
 
     _test_provider("Brookshire Pharmacy #14 #351329", VaccineProvider.BROOKSHIRE, "351329")
 
-    _test_provider("COSTCO PHARMACY #122", VaccineProvider.COSTCO, "122")
     _test_provider("COSTCO MARKET PHARMACY #122", VaccineProvider.COSTCO, "122")
+    _test_provider("COSTCO PHARMACY #122", VaccineProvider.COSTCO, "122")
     _test_provider("Costco Wholesale Corporation #1062", VaccineProvider.COSTCO, "1062")
     _test_provider("Costco Pharmacy # 1014", VaccineProvider.COSTCO, "1014")
+
+    _test_provider("Cub Pharmacy #122 #242356", VaccineProvider.CUB, "242356")
 
     _test_provider("Cvs 104", VaccineProvider.CVS, "104")
     _test_provider("Cvs Store 104", VaccineProvider.CVS, "104")
@@ -32,8 +32,6 @@ def test_provider_id_from_name():
     _test_provider("Cvs StorePharmacy, Inc #104", VaccineProvider.CVS, "104")
     _test_provider("Cvs StorePharmacy, Inc. #104", VaccineProvider.CVS, "104")
     _test_provider("CVS Pharmacy, Inc. #008104", VaccineProvider.CVS, "8104")
-
-    _test_provider("Cub Pharmacy #122 #242356", VaccineProvider.CUB, "242356")
 
     _test_provider("Dillon's Pharmacy #61500005", VaccineProvider.DILLONS, "61500005")
 
@@ -54,13 +52,11 @@ def test_provider_id_from_name():
     _test_provider("Genoa Healthcare 00010 (Chattanooga - Bell Avenue)", VaccineProvider.GENOA, "10")
     _test_provider("Genoa Healthcare LLC #00072", VaccineProvider.GENOA, "72")
 
-    _test_provider("Giant #6269", VaccineProvider.GIANT, "6269")
-
     _test_provider("Giant Eagle Pharmacy #0012 #G00122", VaccineProvider.GIANT_EAGLE, "122")
 
     _test_provider("Giant Food #198", VaccineProvider.GIANT_FOOD, "198")
 
-    _test_provider("H-E-B #198", VaccineProvider.HEB, "198")
+    _test_provider("Giant #6269", VaccineProvider.GIANT, "6269")
 
     _test_provider("Haggen Pharmacy #3450", VaccineProvider.HAGGEN, "3450")
 
@@ -75,9 +71,13 @@ def test_provider_id_from_name():
     _test_provider("Hartig Drug Co #34 #324429", VaccineProvider.HARTIG, "324429")
     _test_provider("Hartig Drug Co 26 #324429", VaccineProvider.HARTIG, "324429")
 
+    _test_provider("H-E-B #198", VaccineProvider.HEB, "198")
+
     _test_provider("Homeland Pharmacy #24429", VaccineProvider.HOMELAND, "24429")
 
     _test_provider("Hy-Vee Inc. #449", VaccineProvider.HY_VEE, "449")
+
+    _test_provider("Ingles Pharmacy #031 #438575", VaccineProvider.INGLES, "438575")
 
     _test_provider("KAISER HEALTH PLAN B PHY 722", VaccineProvider.KAISER_HEALTH_PLAN, "722")
     _test_provider("KAISER HEALTH PLAN BLDG PHY 632", VaccineProvider.KAISER_HEALTH_PLAN, "632")
@@ -91,27 +91,72 @@ def test_provider_id_from_name():
     _test_provider("Kroger Pharmacy #01100330", VaccineProvider.KROGER, "1100330")
     _test_provider("Kroger Pharmacy 743", VaccineProvider.KROGER, "743")
 
-    _test_provider("Ingles Pharmacy #031 #438575", VaccineProvider.INGLES, "438575")
+    _test_provider("Mariano's Pharmacy #53100520", VaccineProvider.MARIANOS, "53100520")
+
+    _test_provider("Medicap Pharmacy #8207 #162543", VaccineProvider.MEDICAP, "162543")
+
+    _test_provider("Meijer #312", VaccineProvider.MEIJER, "312")
+
+    _test_provider("The Little Clinic #36213", VaccineProvider.LITTLE_CLINIC, "36213")
+
+    _test_provider("Market Street Pharmacy #531", VaccineProvider.MARKET_STREET, "531")
+
+    _test_provider("Osco Drug #3272", VaccineProvider.OSCO, "3272")
+    _test_provider("Osco Pharmacy #3272", VaccineProvider.OSCO, "3272")
 
     _test_provider("Pavilions PHARMACY #8545", VaccineProvider.PAVILIONS, "8545")
 
+    _test_provider("Pick N Save Pharmacy #53400102", VaccineProvider.PICK_N_SAVE, "53400102")
+
+    _test_provider("Price Chopper Pharmacy 184 #039929", VaccineProvider.PRICE_CHOPPER, "39929")
+    _test_provider("Price Chopper Pharmacy #20 #MS1004804", VaccineProvider.PRICE_CHOPPER, "1004804")
+
+    _test_provider("Publix Super Markets Inc. #850", VaccineProvider.PUBLIX, "850")
+
+    _test_provider("QFC Pharmacy #70500126", VaccineProvider.QFC, "70500126")
+
+    _test_provider("RALEY'S PHARMACY #339", VaccineProvider.RALEYS, "339")
+
     _test_provider("Rite Aid Pharmacy 3897", VaccineProvider.RITE_AID, "3897")
+    _test_provider("Rite Aid #RA100216", VaccineProvider.RITE_AID, "100216")
 
     _test_provider("Safeway #85", VaccineProvider.SAFEWAY, "85")
     _test_provider("Safeway PHARMACY #85", VaccineProvider.SAFEWAY, "85")
 
     _test_provider("Sam's Pharmacy #6549", VaccineProvider.SAMS, "6549")
+    _test_provider("Sams Club #10-6371", VaccineProvider.SAMS, "6371")
+    _test_provider("Sams Club 6331", VaccineProvider.SAMS, "6331")
+    _test_provider("Sams Pharmacy 10-6371", VaccineProvider.SAMS, "6371")
+
+    _test_provider("SAV-ON PHARMACY #585", VaccineProvider.SAV_ON, "585")
+    _test_provider("SAVON PHARMACY #585", VaccineProvider.SAV_ON, "585")
+
+    _test_provider("Shoprite Pharmacy #447", VaccineProvider.SHOP_RITE, "447")
+
+    _test_provider("Smith's Pharmacy #70600075", VaccineProvider.SMITHS, "70600075")
+
+    _test_provider("Stop & Shop #694", VaccineProvider.STOP_AND_SHOP, "694")
+
+    _test_provider("Tom Thumb Pharmacy #2554", VaccineProvider.TOM_THUMB, "2554")
+
+    _test_provider("Thrifty Drug Stores Inc #5", VaccineProvider.THRIFTY, "5")
 
     _test_provider("Vons Pharmacy #675", VaccineProvider.VONS, "675")
 
     _test_provider("Walgreens #24295", VaccineProvider.WALGREENS, "24295")
+    _test_provider("Walgreens Co. #1158", VaccineProvider.WALGREENS, "1158")
     _test_provider("Walgreens Pharmacy #24295", VaccineProvider.WALGREENS, "24295")
     _test_provider("Walgreens Specialty Pharmacy #35326", VaccineProvider.WALGREENS, "35326")
     _test_provider("Walgreens Specialty #24295", VaccineProvider.WALGREENS, "24295")
 
     _test_provider("Walmart Inc, #2509", VaccineProvider.WALMART, "2509")
+    _test_provider("Walmart Inc #10-1165", VaccineProvider.WALMART, "1165")
     _test_provider("Walmart PHARMACY 10-585", VaccineProvider.WALMART, "585")
     _test_provider("Walmart Pharmacy #1001", VaccineProvider.WALMART, "1001")
+
+    _test_provider("Weis Pharmacy #227 #801371", VaccineProvider.WEIS, "801371")
+
+    _test_provider("Winn-Dixie #435", VaccineProvider.WINN_DIXIE, "435")
 
     # negative cases
     assert provider_id_from_name("garbage") is None

--- a/vaccine_feed_ingest/utils/normalize.py
+++ b/vaccine_feed_ingest/utils/normalize.py
@@ -13,7 +13,6 @@ VACCINE_PROVIDER_REGEXES = {
         re.compile(r"ACME PHARMACY #(\d+)", re.I),
     ],
     VaccineProvider.ALBERTSONS: [
-        re.compile(r"SAV-?ON PHARMACY #\s?(\d+)", re.I),
         re.compile(r"ALBERTSONS(?: MARKET)? PHARMACY #(\d+)", re.I),
     ],
     VaccineProvider.BIG_Y: [
@@ -66,9 +65,6 @@ VACCINE_PROVIDER_REGEXES = {
     VaccineProvider.GIANT_FOOD: [
         re.compile(r"GIANT FOOD #(\d+)", re.I),
     ],
-    VaccineProvider.HEB: [
-        re.compile(r"H-E-B #(\d+)", re.I),
-    ],
     VaccineProvider.HAGGEN: [
         re.compile(r"HAGGEN PHARMACY #(\d+)", re.I),
     ],
@@ -87,11 +83,17 @@ VACCINE_PROVIDER_REGEXES = {
     VaccineProvider.HARTIG: [
         re.compile(r"HARTIG DRUG CO #?\d+ #(\d+)", re.I),
     ],
+    VaccineProvider.HEB: [
+        re.compile(r"H-E-B #(\d+)", re.I),
+    ],
     VaccineProvider.HOMELAND: [
         re.compile(r"HOMELAND PHARMACY #(\d+)", re.I),
     ],
     VaccineProvider.HY_VEE: [
         re.compile(r"HY-VEE INC. #(\d+)", re.I),
+    ],
+    VaccineProvider.INGLES: [
+        re.compile(r"INGLES PHARMACY #\d+ #(\d+)", re.I),
     ],
     VaccineProvider.KAISER_HEALTH_PLAN: [
         re.compile(r"KAISER HEALTH PLAN \w+(?: \w+)? PHY (\d+)", re.I),
@@ -105,30 +107,87 @@ VACCINE_PROVIDER_REGEXES = {
     VaccineProvider.KROGER: [
         re.compile(r"KROGER PHARMACY #?(\d+)", re.I),
     ],
-    VaccineProvider.INGLES: [
-        re.compile(r"INGLES PHARMACY #\d+ #(\d+)", re.I),
+    VaccineProvider.LITTLE_CLINIC: [
+        re.compile(r"THE LITTLE CLINIC #(\d+)", re.I),
+    ],
+    VaccineProvider.MARIANOS: [
+        re.compile(r"MARIANO\'S PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.OSCO: [
+        re.compile(r"OSCO (?:DRUG|PHARMACY) #(\d+)", re.I),
+    ],
+    VaccineProvider.MARKET_STREET: [
+        re.compile(r"MARKET STREET PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.MEDICAP: [
+        re.compile(r"MEDICAP PHARMACY #\d+ #(\d+)", re.I),
+    ],
+    VaccineProvider.MEIJER: [
+        re.compile(r"MEIJER #(\d+)", re.I),
     ],
     VaccineProvider.PAVILIONS: [
         re.compile(r"PAVILIONS PHARMACY #(\d+)", re.I),
     ],
+    VaccineProvider.PICK_N_SAVE: [
+        re.compile(r"PICK N SAVE PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.PRICE_CHOPPER: [
+        re.compile(r"PRICE CHOPPER PHARMACY #?\d+ #(?:MS)?(\d+)", re.I),
+    ],
+    VaccineProvider.PUBLIX: [
+        re.compile(r"PUBLIX SUPER MARKETS INC\. #(\d+)", re.I),
+    ],
+    VaccineProvider.QFC: [
+        re.compile(r"QFC PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.RALEYS: [
+        re.compile(r"RALEY\'S PHARMACY #(\d+)", re.I),
+    ],
     VaccineProvider.RITE_AID: [
-        re.compile(r"RITE AID PHARMACY (\d+)", re.I),
+        re.compile(r"RITE AID (?:PHARMACY |#RA)(\d+)", re.I),
     ],
     VaccineProvider.SAMS: [
         re.compile(r"SAM'?S PHARMACY (?:10-|#\s*)(\d+)", re.I),
+        re.compile(r"SAMS CLUB (?:#\d+\-)?(\d+)", re.I),
     ],
     VaccineProvider.SAFEWAY: [
         re.compile(r"Safeway (?:PHARMACY )?\s?#?(\d+)", re.I),
+    ],
+    VaccineProvider.SAV_ON: [
+        re.compile(r"SAV-?ON PHARMACY #\s?(\d+)", re.I),
+    ],
+    VaccineProvider.SHOP_RITE: [
+        re.compile(r"SHOPRITE PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.SMITHS: [
+        re.compile(r"SMITH\'S PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.STOP_AND_SHOP: [
+        re.compile(r"STOP \& SHOP #(\d+)", re.I),
+    ],
+    VaccineProvider.TOM_THUMB: [
+        re.compile(r"TOM THUMB PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.THRIFTY: [
+        re.compile(r"THRIFTY DRUG STORES INC #(\d+)", re.I),
     ],
     VaccineProvider.VONS: [
         re.compile(r"VONS PHARMACY #(\d+)", re.I),
     ],
     VaccineProvider.WALGREENS: [
         re.compile(r"Walgreens (?:Specialty )?(?:Pharmacy )?#(\d+)", re.I),
+        re.compile(r"Walgreens Co\. #(\d+)", re.I),
     ],
     VaccineProvider.WALMART: [
+        re.compile(r"WALMART INC #10-(\d+)", re.I),
         re.compile(r"WALMART PHARMACY 10-(\d+)", re.I),
         re.compile(r"WALMART (?:INC,|PHARMACY) #(\d+)", re.I),
+    ],
+    VaccineProvider.WEIS: [
+        re.compile(r"WEIS PHARMACY #\d+ #(\d+)", re.I),
+    ],
+    VaccineProvider.WINN_DIXIE: [
+        re.compile(r"WINN-DIXIE #(\d+)", re.I),
     ],
 }
 


### PR DESCRIPTION
| Key Details |
|-|
| Resolves: #254 |
State: |
Site: |

## Notes

Continuation of work started with #332. This PR builds on https://github.com/CAVaccineInventory/vaccine-feed-ingest-schema/pull/21 to add support of extraction of more vaccine providers.

This PR also refactors the provider_id code to make it easier to maintain and extend by extract config out of code.

## Data sample

I will run the runners shortly ...

## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
