### PR TITLE
Turn provider regexs into constants and group them by provider. 

### DIFF
--- a/vaccine_feed_ingest/utils/normalize.py
+++ b/vaccine_feed_ingest/utils/normalize.py
@@ -7,142 +7,142 @@ from typing import Optional, Tuple
 import url_normalize
 from vaccine_feed_ingest_schema.location import VaccineProvider
 
+# Add to this list in alphabetical order
+VACCINE_PROVIDER_REGEXES = {
+    VaccineProvider.ACME: [
+        re.compile(r"ACME PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.ALBERTSONS: [
+        re.compile(r"SAV-?ON PHARMACY #\s?(\d+)", re.I),
+        re.compile(r"ALBERTSONS(?: MARKET)? PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.BIG_Y: [
+        re.compile(r"BIG Y PHARMACY(?: #\d+ Rx)? #(\d+)", re.I),
+    ],
+    VaccineProvider.BROOKSHIRE: [
+        re.compile(r"BROOKSHIRE PHARMACY #\d+ #(\d+)", re.I),
+    ],
+    VaccineProvider.COSTCO: [
+        re.compile(r"COSTCO(?: MARKET)? PHARMACY #\s*(\d+)", re.I),
+        re.compile(r"COSTCO WHOLESALE CORPORATION #(\d+)", re.I),
+    ],
+    VaccineProvider.CUB: [
+        re.compile(r"CUB PHARMACY #\d+ #(\d+)", re.I),
+    ],
+    VaccineProvider.CVS: [
+        re.compile(r"CVS\s(?:STORE)?(?:PHARMACY)?(?:, INC.?)?\s?#?(\d+)", re.I),
+    ],
+    VaccineProvider.DILLONS: [
+        re.compile(r"DILLON\'S PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.DRUGCO: [
+        re.compile(r"DRUGCO DISCOUNT PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.FAMILY_FARE: [
+        re.compile(r"FAMILY\s+FARE\s+PHARMACY\s+#?\d+\s+#(\d+)", re.I),
+    ],
+    VaccineProvider.FOOD_CITY: [
+        re.compile(r"FOOD CITY PHARMACY #\d+ #(\d+)", re.I),
+    ],
+    VaccineProvider.FOOD_LION: [
+        re.compile(r"FOOD LION #(\d+)", re.I),
+    ],
+    VaccineProvider.FRED_MEYER: [
+        re.compile(r"FRED MEYER(?: PHARMACY)? #(\d+)", re.I),
+    ],
+    VaccineProvider.FRYS: [
+        re.compile(r"FRY\'S FOOD AND DRUG #(\d+)", re.I),
+    ],
+    VaccineProvider.GENOA: [
+        re.compile(r"GENOA HEALTHCARE (\d+) \(", re.I),
+        re.compile(r"GENOA HEALTHCARE LLC #(\d+)", re.I),
+    ],
+    VaccineProvider.GIANT: [
+        re.compile(r"GIANT #(\d+)", re.I),
+    ],
+    VaccineProvider.GIANT_EAGLE: [
+        re.compile(r"GIANT EAGLE PHARMACY #\d+ #G(\d+)", re.I),
+    ],
+    VaccineProvider.GIANT_FOOD: [
+        re.compile(r"GIANT FOOD #(\d+)", re.I),
+    ],
+    VaccineProvider.HEB: [
+        re.compile(r"H-E-B #(\d+)", re.I),
+    ],
+    VaccineProvider.HAGGEN: [
+        re.compile(r"HAGGEN PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.HANNAFORD: [
+        re.compile(r"HANNAFORD #(\d+)", re.I),
+    ],
+    VaccineProvider.HARMONS: [
+        re.compile(r"HARMONS PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.HARPS: [
+        re.compile(r"HARPS PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.HARRIS_TEETER: [
+        re.compile(r"HARRIS TEETER PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.HARTIG: [
+        re.compile(r"HARTIG DRUG CO #?\d+ #(\d+)", re.I),
+    ],
+    VaccineProvider.HOMELAND: [
+        re.compile(r"HOMELAND PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.HY_VEE: [
+        re.compile(r"HY-VEE INC. #(\d+)", re.I),
+    ],
+    VaccineProvider.KAISER_HEALTH_PLAN: [
+        re.compile(r"KAISER HEALTH PLAN \w+(?: \w+)? PHY (\d+)", re.I),
+    ],
+    VaccineProvider.KAISER_PERMANENTE: [
+        re.compile(r"KAISER PERMANENTE PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.KING_SOOPERS: [
+        re.compile(r"KING SOOPERS PHARMACY #?(\d+)", re.I),
+    ],
+    VaccineProvider.KROGER: [
+        re.compile(r"KROGER PHARMACY #?(\d+)", re.I),
+    ],
+    VaccineProvider.INGLES: [
+        re.compile(r"INGLES PHARMACY #\d+ #(\d+)", re.I),
+    ],
+    VaccineProvider.PAVILIONS: [
+        re.compile(r"PAVILIONS PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.RITE_AID: [
+        re.compile(r"RITE AID PHARMACY (\d+)", re.I),
+    ],
+    VaccineProvider.SAMS: [
+        re.compile(r"SAM'?S PHARMACY (?:10-|#\s*)(\d+)", re.I),
+    ],
+    VaccineProvider.SAFEWAY: [
+        re.compile(r"Safeway (?:PHARMACY )?\s?#?(\d+)", re.I),
+    ],
+    VaccineProvider.VONS: [
+        re.compile(r"VONS PHARMACY #(\d+)", re.I),
+    ],
+    VaccineProvider.WALGREENS: [
+        re.compile(r"Walgreens (?:Specialty )?(?:Pharmacy )?#(\d+)", re.I),
+    ],
+    VaccineProvider.WALMART: [
+        re.compile(r"WALMART PHARMACY 10-(\d+)", re.I),
+        re.compile(r"WALMART (?:INC,|PHARMACY) #(\d+)", re.I),
+    ],
+}
+
 
 def provider_id_from_name(
     name: str,
 ) -> Optional[Tuple[VaccineProvider, str]]:
     """Generate provider ids for retail pharmacies (riteaid:123)"""
 
-    m = re.search(r"RITE AID PHARMACY (\d+)", name, re.I)
-    if m:
-        return VaccineProvider.RITE_AID, str(int(m.group(1)))
-    m = re.search(r"Walgreens (?:Specialty )?(?:Pharmacy )?#(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.WALGREENS, str(int(m.group(1)))
-    m = re.search(r"Safeway (?:PHARMACY )?\s?#?(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.SAFEWAY, str(int(m.group(1)))
-    m = re.search(r"VONS PHARMACY #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.VONS, str(int(m.group(1)))
-    m = re.search(r"SAM'?S PHARMACY (?:10-|#\s*)(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.SAMS, str(int(m.group(1)))
-    m = re.search(r"SAV-?ON PHARMACY #\s?(\d+)", name, re.I)
-    if m:
-        # These are albertsons locations
-        return VaccineProvider.ALBERTSONS, str(int(m.group(1)))
-    m = re.search(r"PAVILIONS PHARMACY #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.PAVILIONS, str(int(m.group(1)))
-    m = re.search(r"WALMART PHARMACY 10-(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.WALMART, str(int(m.group(1)))
-    m = re.search(r"WALMART (?:INC,|PHARMACY) #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.WALMART, str(int(m.group(1)))
-    m = re.search(r"CVS\s(?:STORE)?(?:PHARMACY)?(?:, INC.?)?\s?#?(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.CVS, str(int(m.group(1)))
-    m = re.search(r"ACME PHARMACY #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.ACME, str(int(m.group(1)))
-    m = re.search(r"ALBERTSONS(?: MARKET)? PHARMACY #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.ALBERTSONS, str(int(m.group(1)))
-    m = re.search(r"BIG Y PHARMACY(?: #\d+ Rx)? #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.BIG_Y, str(int(m.group(1)))
-    m = re.search(r"BROOKSHIRE PHARMACY #\d+ #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.BROOKSHIRE, str(int(m.group(1)))
-    m = re.search(r"COSTCO(?: MARKET)? PHARMACY #\s*(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.COSTCO, str(int(m.group(1)))
-    m = re.search(r"COSTCO WHOLESALE CORPORATION #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.COSTCO, str(int(m.group(1)))
-    m = re.search(r"CUB PHARMACY #\d+ #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.CUB, str(int(m.group(1)))
-    m = re.search(r"DILLON\'S PHARMACY #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.DILLONS, str(int(m.group(1)))
-    m = re.search(r"DRUGCO DISCOUNT PHARMACY #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.DRUGCO, str(int(m.group(1)))
-    m = re.search(r"FAMILY\s+FARE\s+PHARMACY\s+#?\d+\s+#(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.FAMILY_FARE, str(int(m.group(1)))
-    m = re.search(r"FOOD CITY PHARMACY #\d+ #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.FOOD_CITY, str(int(m.group(1)))
-    m = re.search(r"FOOD LION #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.FOOD_LION, str(int(m.group(1)))
-    m = re.search(r"FRED MEYER(?: PHARMACY)? #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.FRED_MEYER, str(int(m.group(1)))
-    m = re.search(r"FRY\'S FOOD AND DRUG #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.FRYS, str(int(m.group(1)))
-    m = re.search(r"GENOA HEALTHCARE (\d+) \(", name, re.I)
-    if m:
-        return VaccineProvider.GENOA, str(int(m.group(1)))
-    m = re.search(r"GENOA HEALTHCARE LLC #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.GENOA, str(int(m.group(1)))
-    m = re.search(r"GIANT #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.GIANT, str(int(m.group(1)))
-    m = re.search(r"GIANT EAGLE PHARMACY #\d+ #G(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.GIANT_EAGLE, str(int(m.group(1)))
-    m = re.search(r"GIANT FOOD #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.GIANT_FOOD, str(int(m.group(1)))
-    m = re.search(r"H-E-B #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.HEB, str(int(m.group(1)))
-    m = re.search(r"HAGGEN PHARMACY #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.HAGGEN, str(int(m.group(1)))
-    m = re.search(r"HANNAFORD #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.HANNAFORD, str(int(m.group(1)))
-    m = re.search(r"HARMONS PHARMACY #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.HARMONS, str(int(m.group(1)))
-    m = re.search(r"HARPS PHARMACY #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.HARPS, str(int(m.group(1)))
-    m = re.search(r"HARRIS TEETER PHARMACY #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.HARRIS_TEETER, str(int(m.group(1)))
-    m = re.search(r"HARTIG DRUG CO #?\d+ #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.HARTIG, str(int(m.group(1)))
-    m = re.search(r"HOMELAND PHARMACY #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.HOMELAND, str(int(m.group(1)))
-    m = re.search(r"HY-VEE INC. #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.HY_VEE, str(int(m.group(1)))
-    m = re.search(r"KAISER HEALTH PLAN \w+(?: \w+)? PHY (\d+)", name, re.I)
-    if m:
-        return VaccineProvider.KAISER_HEALTH_PLAN, str(int(m.group(1)))
-    m = re.search(r"KAISER PERMANENTE PHARMACY #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.KAISER_PERMANENTE, str(int(m.group(1)))
-    m = re.search(r"KING SOOPERS PHARMACY #?(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.KING_SOOPERS, str(int(m.group(1)))
-    m = re.search(r"KROGER PHARMACY #?(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.KROGER, str(int(m.group(1)))
-    m = re.search(r"INGLES PHARMACY #\d+ #(\d+)", name, re.I)
-    if m:
-        return VaccineProvider.INGLES, str(int(m.group(1)))
+    for vaccine_provider, regexes in VACCINE_PROVIDER_REGEXES.items():
+        for regex in regexes:
+            m = regex.search(name)
+            if m:
+                return vaccine_provider, str(int(m.group(1)))
 
     return None
 


### PR DESCRIPTION
Turn provider regexs into constants and group them by provider. 

This was introduced in #360 and I wanted to get that improvement in without while we discuss the merits of umbrella org vs. brand.