### PR TITLE
add parser for dc/district

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,10 +30,10 @@ commands =
 deps =
   lint
 commands =
-  poetry run flake8 vaccine_feed_ingest
   poetry run isort vaccine_feed_ingest
   poetry run black vaccine_feed_ingest
   poetry run mypy vaccine_feed_ingest
+  poetry run flake8 vaccine_feed_ingest
 
 
 [testenv:test]

--- a/vaccine_feed_ingest/runners/dc/district/parse.py
+++ b/vaccine_feed_ingest/runners/dc/district/parse.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import json
+import pathlib
+import sys
+
+from bs4 import BeautifulSoup
+
+input_dir = pathlib.Path(sys.argv[2])
+input_file = input_dir / "data.html"
+output_dir = pathlib.Path(sys.argv[1])
+output_file = output_dir / "data.parsed.ndjson"
+
+with input_file.open() as fin:
+    soup = BeautifulSoup(fin, "html.parser")
+
+table = soup.find("h4", string="Walk-Up Locations").find_next_sibling("table")
+headers = [h.text.strip().replace("\xa0", " ") for h in table.select("thead th")]
+
+sites = []
+for row in table.select("tbody tr"):
+    cells = [c.text.strip().replace("\xa0", " ") for c in row.find_all("td")]
+    sites.append(dict(zip(headers, cells)))
+
+with output_file.open("w") as fout:
+    for site in sites:
+        json.dump(site, fout)
+        fout.write("\n")


### PR DESCRIPTION
# Parse district for DC<!-- <stage> <site> for <state> (e.g.,  Normalize ArcGIS for MD) -->

| Key Details |
|-|
| Resolves #401<!-- ISSUE_NUM --> |
State: DC<!-- two-letter abbreviation like md or us --> |
Site: district<!-- name of site, like vaccinespotter_org or arcgis--> |

## Notes

I also updated tox.ini so `tox -e lint-fix` so that flake8 runs _after_ black et al. have cleaned up the code for us.  Otherwise, flake8 blows up on things that black/isort would have fixed anyway.

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```json
{"Walk-Up Site": "Arena Stage", "Address": "1101 6th St SW", "Normal Days / Hours": "Thursday-Sunday \n8am-12pm, 1pm-5pm", "Vaccine": "Pfizer", "May 1 Walk-Up": "Pfizer \n8am-12pm and 1pm-5pm"}
{"Walk-Up Site": "Entertainment and Sports Arena", "Address": "1100 Oak St SE", "Normal Days / Hours": "Switching to RISE after May 1", "Vaccine": "Pfizer", "May 1 Walk-Up": "Pfizer \n9am-5pm"}
{"Walk-Up Site": "Fort Stanton Rec Center", "Address": "1812 Erie St, SE", "Normal Days / Hours": "May 3-May 6 and May 10-May13 \n9am-1pm \nMay 24-May 27 \n2pm-7pm", "Vaccine": "Pfizer", "May 1 Walk-Up": "Johnson & Johnson (J&J only on May 1)\n9am-3pm"}
{"Walk-Up Site": "Kenilworth Rec Center", "Address": "4321 Ord St, NE", "Normal Days / Hours": "Tues/Wed/Fri  \n10A-4P", "Vaccine": "Moderna", "May 1 Walk-Up": "NOT OPEN 5/1"}
{"Walk-Up Site": "Lamond Rec Center", "Address": "20 Tuckerman St, NE", "Normal Days / Hours": "May 5-May 8: \n9am-1pm \nMay 12-15, 19-22, 26-29: 2pm-7pm", "Vaccine": "Pfizer", "May 1 Walk-Up": "Pfizer \n9am-1pm"}
```

## Before Opening a PR
- [ ✅ ] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [ ✅ ] I ran auto-formatting: `poetry run tox -e lint-fix`
