### PR TITLE
chore: remove networkId as link in ct

### DIFF
--- a/vaccine_feed_ingest/runners/ct/covidvaccinefinder_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/ct/covidvaccinefinder_gov/normalize.py
@@ -91,7 +91,6 @@ def _get_inventory(site: dict) -> List[schema.Vaccine]:
 def normalize(site: dict, timestamp: str) -> dict:
     links = [
         schema.Link(authority="ct_gov", id=site["_id"]),
-        schema.Link(authority="ct_gov_network_id", id=site["networkId"]),
     ]
 
     parent_organization = schema.Organization(name=site["networks"][0]["name"])


### PR DESCRIPTION
Linking on networkId is causing locations in the same network (e.g., Walgreens) to match with each other when they should not. Remove the link.