### PR TITLE
Fetch Vaccinate NJ for NJ

### DIFF
--- a/vaccine_feed_ingest/runners/nj/vaccinate_nj/fetch.py
+++ b/vaccine_feed_ingest/runners/nj/vaccinate_nj/fetch.py
@@ -1,0 +1,23 @@
+import requests
+import json
+import sys
+
+LARGE_NUMBER_FAR_EXCEEDING_NUMBER_OF_POTENTIAL_VACCINATION_SITES = 1000000
+data = {
+   "draw":1,
+   "columns":[],
+   "order":[],
+   "start":0,
+   "length":LARGE_NUMBER_FAR_EXCEEDING_NUMBER_OF_POTENTIAL_VACCINATION_SITES,
+   "search":{
+      "value":"",
+      "regex":False
+   }
+}
+url = "https://c19vaccinelocatornj.info/api/v1/vaccine/locations/page"
+result = requests.post(url, json=data)
+assert result.status_code == 200
+
+output_path = str(sys.argv[1])
+with open(output_path, 'w') as f:
+    json.dump(json.loads(result.content), f)

--- a/vaccine_feed_ingest/runners/nj/vaccinate_nj/fetch.py
+++ b/vaccine_feed_ingest/runners/nj/vaccinate_nj/fetch.py
@@ -1,23 +1,21 @@
-import requests
 import json
 import sys
 
+import requests
+
 LARGE_NUMBER_FAR_EXCEEDING_NUMBER_OF_POTENTIAL_VACCINATION_SITES = 1000000
 data = {
-   "draw":1,
-   "columns":[],
-   "order":[],
-   "start":0,
-   "length":LARGE_NUMBER_FAR_EXCEEDING_NUMBER_OF_POTENTIAL_VACCINATION_SITES,
-   "search":{
-      "value":"",
-      "regex":False
-   }
+    "draw": 1,
+    "columns": [],
+    "order": [],
+    "start": 0,
+    "length": LARGE_NUMBER_FAR_EXCEEDING_NUMBER_OF_POTENTIAL_VACCINATION_SITES,
+    "search": {"value": "", "regex": False},
 }
 url = "https://c19vaccinelocatornj.info/api/v1/vaccine/locations/page"
 result = requests.post(url, json=data)
 assert result.status_code == 200
 
 output_path = str(sys.argv[1])
-with open(output_path, 'w') as f:
+with open(output_path, "w") as f:
     json.dump(json.loads(result.content), f)


### PR DESCRIPTION
| Key Details |
|-|
| Resolves #555  |
State: NJ |
Site: Vaccinate NJ |

## Notes
The data is currently displayed at vaccinatenj.com/availability using an iframe in the HTML, but the Datatable itself which acts as a frontend to the database is at https://c19vaccinelocatornj.info instead, hence the url.

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```json
{"data": [{"name": "Rite Aid #10454", "id": "a330a478-6171-47dc-8b5b-fcbd73b9f298", "city": "Moorestown", "zipCode": "08057", "county": "Burlington", "url": "https://www.riteaid.com/pharmacy/covid-qualifier", "type": "Pharmacy", "availabilityStatus": "Available", "availabilityChangedDate": "2021-04-29T15:47:46Z", "address": "121 West Main Street", "phone": "(800) 748-3243", "createdDate": "2021-03-28T00:43:43Z", "updatedDate": "2021-05-06T00:16:07Z", "scheduling": ["Online"], "lastCheckedDate": "2021-05-06T00:14:05Z", "eligibility": "State Wide", "geoCode": {"latitude": 39.9630056, "longitude": -74.9494184, "type": "ROOFTOP"}},
```

## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
