### PR TITLE
Parse clinic_list for AK

### DIFF
--- a/vaccine_feed_ingest/runners/ak/clinic_list/parse.yml
+++ b/vaccine_feed_ingest/runners/ak/clinic_list/parse.yml
@@ -1,0 +1,4 @@
+---
+state: ak
+site: clinic_list
+parser: arcgis_features


### PR DESCRIPTION
# <!-- <stage> <site> for <state> (e.g.,  Normalize ArcGIS for MD) -->

| Key Details |
|-|
| Resolves #497  |
State: AK |
Site: clinic_list |

## Notes
For some reason, they're using `flu_vaccinations` etc. to represent COVID vaccinations data. Sigh.

## Data sample
```json
{"attributes": {"CreationDate": 1608936294888, "Creator": "", "EditDate": 1617228680475, "Editor": "kelly.isham_Alaska_DHSS", "address": "579 Kongosak St", "adminContactName": "Andrey Boskhomdzhiev\nNSB PHN Program Coordinator \n907-852-0270\nandrey.boskhomdzhiev@north-slope.org\n", "adminEmail": "andrey.boskhomdzhiev@north-slope.org", "city": "Barrow", "cost_other": null, "datesubmited": 1608930000000, "flu_acceptsInsurance": "yes_please_contact_your_insuran", "flu_cost": "no_cost", "flu_vaccinations": "pfizer", "flu_walkins": "no_please_make_an_appointment", "globalid": "85b07ac7-c9b6-4d09-83ec-a720998c2fbf", "layer_id": 0, "objectid": 9, "phone": "907-852-0270", "publicEmail": null, "publicNotes": "NSB PHN Wellness clinic, please call for appointments 907-852-0270", "publicWebsite": null, "service_item_id": "7b65a9e852524227be91ad45d613da33", "vaccinationSite": "North Slope Borough Public Health Nursing-Wellness", "zipcode": "99723"}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -156.7920099649541, "y": 71.29069998454801}}
```

## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
