### PR TITLE
Improve matcher to look at phone numbers and providers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1245,6 +1245,14 @@ python-versions = "*"
 ptyprocess = ">=0.5"
 
 [[package]]
+name = "phonenumbers"
+version = "8.12.22"
+description = "Python version of Google's common library for parsing, formatting, storing and validating international phone numbers."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pickleshare"
 version = "0.7.5"
 description = "Tiny 'shelve'-like database with concurrency support"
@@ -2043,7 +2051,7 @@ test = ["pytest", "pytest-runner"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "d38a12a667c2861cc2fd304f337a57e66dc35aaf46b797aa454aabed9dab9e38"
+content-hash = "7a7f9ea3f76f2d41415902324ee5a5b355e7dedd7600b19288e77534a40ce517"
 
 [metadata.files]
 aiohttp = [
@@ -2475,40 +2483,30 @@ lxml = [
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4bff24dfeea62f2e56f5bab929b4428ae6caba2d1eea0c2d6eb618e30a71e6d4"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"},
-    {file = "lxml-4.6.3-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:4c61b3a0db43a1607d6264166b230438f85bfed02e8cff20c22e564d0faff354"},
-    {file = "lxml-4.6.3-cp35-cp35m-manylinux2014_x86_64.whl", hash = "sha256:5c8c163396cc0df3fd151b927e74f6e4acd67160d6c33304e805b84293351d16"},
     {file = "lxml-4.6.3-cp35-cp35m-win32.whl", hash = "sha256:f2380a6376dfa090227b663f9678150ef27543483055cc327555fb592c5967e2"},
     {file = "lxml-4.6.3-cp35-cp35m-win_amd64.whl", hash = "sha256:c4f05c5a7c49d2fb70223d0d5bcfbe474cf928310ac9fa6a7c6dddc831d0b1d4"},
     {file = "lxml-4.6.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d2e35d7bf1c1ac8c538f88d26b396e73dd81440d59c1ef8522e1ea77b345ede4"},
     {file = "lxml-4.6.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:289e9ca1a9287f08daaf796d96e06cb2bc2958891d7911ac7cae1c5f9e1e0ee3"},
     {file = "lxml-4.6.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:bccbfc27563652de7dc9bdc595cb25e90b59c5f8e23e806ed0fd623755b6565d"},
-    {file = "lxml-4.6.3-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d916d31fd85b2f78c76400d625076d9124de3e4bda8b016d25a050cc7d603f24"},
     {file = "lxml-4.6.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:820628b7b3135403540202e60551e741f9b6d3304371712521be939470b454ec"},
-    {file = "lxml-4.6.3-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:c47ff7e0a36d4efac9fd692cfa33fbd0636674c102e9e8d9b26e1b93a94e7617"},
     {file = "lxml-4.6.3-cp36-cp36m-win32.whl", hash = "sha256:5a0a14e264069c03e46f926be0d8919f4105c1623d620e7ec0e612a2e9bf1c04"},
     {file = "lxml-4.6.3-cp36-cp36m-win_amd64.whl", hash = "sha256:92e821e43ad382332eade6812e298dc9701c75fe289f2a2d39c7960b43d1e92a"},
     {file = "lxml-4.6.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:efd7a09678fd8b53117f6bae4fa3825e0a22b03ef0a932e070c0bdbb3a35e654"},
     {file = "lxml-4.6.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:efac139c3f0bf4f0939f9375af4b02c5ad83a622de52d6dfa8e438e8e01d0eb0"},
     {file = "lxml-4.6.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:0fbcf5565ac01dff87cbfc0ff323515c823081c5777a9fc7703ff58388c258c3"},
-    {file = "lxml-4.6.3-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:36108c73739985979bf302006527cf8a20515ce444ba916281d1c43938b8bb96"},
     {file = "lxml-4.6.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:122fba10466c7bd4178b07dba427aa516286b846b2cbd6f6169141917283aae2"},
-    {file = "lxml-4.6.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:cdaf11d2bd275bf391b5308f86731e5194a21af45fbaaaf1d9e8147b9160ea92"},
     {file = "lxml-4.6.3-cp37-cp37m-win32.whl", hash = "sha256:3439c71103ef0e904ea0a1901611863e51f50b5cd5e8654a151740fde5e1cade"},
     {file = "lxml-4.6.3-cp37-cp37m-win_amd64.whl", hash = "sha256:4289728b5e2000a4ad4ab8da6e1db2e093c63c08bdc0414799ee776a3f78da4b"},
     {file = "lxml-4.6.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b007cbb845b28db4fb8b6a5cdcbf65bacb16a8bd328b53cbc0698688a68e1caa"},
     {file = "lxml-4.6.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:76fa7b1362d19f8fbd3e75fe2fb7c79359b0af8747e6f7141c338f0bee2f871a"},
     {file = "lxml-4.6.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:26e761ab5b07adf5f555ee82fb4bfc35bf93750499c6c7614bd64d12aaa67927"},
-    {file = "lxml-4.6.3-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:e1cbd3f19a61e27e011e02f9600837b921ac661f0c40560eefb366e4e4fb275e"},
     {file = "lxml-4.6.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:66e575c62792c3f9ca47cb8b6fab9e35bab91360c783d1606f758761810c9791"},
-    {file = "lxml-4.6.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:1b38116b6e628118dea5b2186ee6820ab138dbb1e24a13e478490c7db2f326ae"},
     {file = "lxml-4.6.3-cp38-cp38-win32.whl", hash = "sha256:89b8b22a5ff72d89d48d0e62abb14340d9e99fd637d046c27b8b257a01ffbe28"},
     {file = "lxml-4.6.3-cp38-cp38-win_amd64.whl", hash = "sha256:2a9d50e69aac3ebee695424f7dbd7b8c6d6eb7de2a2eb6b0f6c7db6aa41e02b7"},
     {file = "lxml-4.6.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ce256aaa50f6cc9a649c51be3cd4ff142d67295bfc4f490c9134d0f9f6d58ef0"},
     {file = "lxml-4.6.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:7610b8c31688f0b1be0ef882889817939490a36d0ee880ea562a4e1399c447a1"},
     {file = "lxml-4.6.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f8380c03e45cf09f8557bdaa41e1fa7c81f3ae22828e1db470ab2a6c96d8bc23"},
-    {file = "lxml-4.6.3-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:3082c518be8e97324390614dacd041bb1358c882d77108ca1957ba47738d9d59"},
     {file = "lxml-4.6.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:884ab9b29feaca361f7f88d811b1eea9bfca36cf3da27768d28ad45c3ee6f969"},
-    {file = "lxml-4.6.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:6f12e1427285008fd32a6025e38e977d44d6382cf28e7201ed10d6c1698d2a9a"},
     {file = "lxml-4.6.3-cp39-cp39-win32.whl", hash = "sha256:33bb934a044cf32157c12bfcfbb6649807da20aa92c062ef51903415c704704f"},
     {file = "lxml-4.6.3-cp39-cp39-win_amd64.whl", hash = "sha256:542d454665a3e277f76954418124d67516c5f88e51a900365ed54a9806122b83"},
     {file = "lxml-4.6.3.tar.gz", hash = "sha256:39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468"},
@@ -2769,6 +2767,10 @@ pathy = [
 pexpect = [
     {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
     {file = "pexpect-4.8.0.tar.gz", hash = "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"},
+]
+phonenumbers = [
+    {file = "phonenumbers-8.12.22-py2.py3-none-any.whl", hash = "sha256:f9cb4882e5c7daeaa183af7b0390c44a02604731c7aab561d9456e1df4582207"},
+    {file = "phonenumbers-8.12.22.tar.gz", hash = "sha256:b20765cb9d1392308071a3462c06edcaa953cb383e3565f5fc0a6fb93f240150"},
 ]
 pickleshare = [
     {file = "pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ lxml = "^4.6.3"
 pykml = "^0.2.0"
 html5lib = "^1.1"
 url-normalize = "^1.4.3"
+phonenumbers = "^8.12.22"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.23.1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,6 @@ def full_location():
         name="Rite Aid Pharmacy 5952",
         address=location.Address(
             street1="1991 Mountain Boulevard",
-            street2="#1",
             city="Oakland",
             state="CA",
             zip="94611",
@@ -34,7 +33,11 @@ def full_location():
             location.Contact(
                 contact_type=location.ContactType.BOOKING,
                 phone="(916) 445-2841",
-            )
+            ),
+            location.Contact(
+                contact_type=location.ContactType.GENERAL,
+                phone="(510) 339-2215",
+            ),
         ],
         languages=["en"],
         opening_dates=[
@@ -67,7 +70,7 @@ def full_location():
         ),
         parent_organization=location.Organization(
             id=location.VaccineProvider.RITE_AID,
-            name="Rite Aid",
+            name="Rite Aid Pharmacy",
         ),
         links=[
             location.Link(
@@ -86,3 +89,33 @@ def full_location():
             data={"id": "dad13365-2202-4dea-9b37-535288b524fe"},
         ),
     )
+
+
+@pytest.fixture
+def vial_location():
+    return {
+        "type": "Feature",
+        "properties": {
+            "id": "recmq8dNXlV1yWipP",
+            "name": "RITE AID PHARMACY 05952",
+            "state": "CA",
+            "latitude": 37.82733,
+            "longitude": -122.21058,
+            "location_type": "Pharmacy",
+            "import_ref": "vca-airtable:recmq8dNXlV1yWipP",
+            "phone_number": "510-339-2215",
+            "full_address": "1991 MOUNTAIN BOULEVARD, OAKLAND, CA 94611",
+            "county": "Alameda",
+            "google_places_id": "ChIJA0MOOYWHj4ARW8M-vrC9yGA",
+            "vaccinefinder_location_id": "ed4af07f-1a17-408b-b705-7c982b7d25d6",
+            "vaccinespotter_location_id": "7384085",
+            "hours": "Monday - Friday: 9:00 AM \u2013 9:00 PM\nSaturday: 9:00 AM \u2013 6:00 PM\nSunday: 10:00 AM \u2013 6:00 PM",
+            "provider": {"name": "Rite-Aid Pharmacy", "type": "Pharmacy"},
+            "concordances": [
+                "google_places:ChIJA0MOOYWHj4ARW8M-vrC9yGA",
+                "vaccinefinder:ed4af07f-1a17-408b-b705-7c982b7d25d6",
+                "vaccinespotter_org:7384085",
+            ],
+        },
+        "geometry": {"type": "Point", "coordinates": [-122.21058, 37.82733]},
+    }

--- a/tests/utils/test_match.py
+++ b/tests/utils/test_match.py
@@ -1,0 +1,13 @@
+from vaccine_feed_ingest.utils import match
+
+
+def test_is_address_similar(full_location, vial_location):
+    assert match.is_address_similar(full_location, vial_location)
+
+
+def test_is_provider_similar(full_location, vial_location):
+    assert match.is_provider_similar(full_location, vial_location)
+
+
+def test_has_matching_phone_number(full_location, vial_location):
+    assert match.has_matching_phone_number(full_location, vial_location)

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -259,6 +259,11 @@ def _is_match(source: location.NormalizedLocation, candidate: dict) -> bool:
         # Shared concordances, mark as match
         return True
 
+    # Don't match locations with different providers
+    provider_matches = is_provider_similar(source, candidate, threshold=0.7)
+    if provider_matches is not None and provider_matches is False:
+        return False
+
     address_matches = is_address_similar(source, candidate)
     if address_matches is not None and address_matches is True:
         return True

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -14,7 +14,9 @@ from vaccine_feed_ingest.utils.log import getLogger
 
 from .. import vial
 from ..utils.match import (
+    has_matching_phone_number,
     is_address_similar,
+    is_provider_similar,
 )
 from . import outputs
 from .common import STAGE_OUTPUT_SUFFIX, PipelineStage
@@ -262,6 +264,11 @@ def _is_match(source: location.NormalizedLocation, candidate: dict) -> bool:
     # Don't match locations with different providers
     provider_matches = is_provider_similar(source, candidate, threshold=0.7)
     if provider_matches is not None and provider_matches is False:
+        return False
+
+    # If there are phone numbers and the phone numbers don't match then fail to match
+    phone_matches = has_matching_phone_number(source, candidate)
+    if phone_matches is not None and phone_matches is False:
         return False
 
     address_matches = is_address_similar(source, candidate)

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -13,7 +13,9 @@ from vaccine_feed_ingest_schema import load, location
 from vaccine_feed_ingest.utils.log import getLogger
 
 from .. import vial
-from ..utils.match import canonicalize_address, get_full_address
+from ..utils.match import (
+    is_address_similar,
+)
 from . import outputs
 from .common import STAGE_OUTPUT_SUFFIX, PipelineStage
 
@@ -244,9 +246,12 @@ def _is_match(source: location.NormalizedLocation, candidate: dict) -> bool:
         else set()
     )
 
-    candidate = candidate["properties"]
+    candidate_props = candidate["properties"]
+
     candidate_links = (
-        set(candidate["concordances"]) if "concordances" in candidate else set()
+        set(candidate_props["concordances"])
+        if "concordances" in candidate_props
+        else set()
     )
     shared_links = source_links.intersection(candidate_links)
 
@@ -254,12 +259,9 @@ def _is_match(source: location.NormalizedLocation, candidate: dict) -> bool:
         # Shared concordances, mark as match
         return True
 
-    if candidate["full_address"] is not None and source.address is not None:
-        if canonicalize_address(
-            get_full_address(source.address)
-        ) == canonicalize_address(candidate["full_address"]):
-            # Canonicalized address matches, mark as match
-            return True
+    address_matches = is_address_similar(source, candidate)
+    if address_matches is not None and address_matches is True:
+        return True
 
     return False
 

--- a/vaccine_feed_ingest/utils/match.py
+++ b/vaccine_feed_ingest/utils/match.py
@@ -121,7 +121,7 @@ def has_matching_phone_number(
         try:
             src_phones.append(phonenumbers.parse(contact.phone, "US"))
         except phonenumbers.NumberParseException:
-            logger.warning("Invalid phone number: %s", contact.phone)
+            logger.warning("Invalid source phone number for location %s: %s", source.id, contact.phone)
             continue
 
     if not src_phones:

--- a/vaccine_feed_ingest/utils/match.py
+++ b/vaccine_feed_ingest/utils/match.py
@@ -110,7 +110,7 @@ def has_matching_phone_number(
     try:
         cand_phone = phonenumbers.parse(candidate_props["phone_number"], "US")
     except phonenumbers.NumberParseException:
-        logger.warning("Invalid phone number: %s", candidate_props["phone_number"])
+        logger.warning("Invalid candidate phone number for location %s: %s", <an_id_field>, candidate_props["phone_number"])
         return None
 
     src_phones = []

--- a/vaccine_feed_ingest/utils/match.py
+++ b/vaccine_feed_ingest/utils/match.py
@@ -110,7 +110,11 @@ def has_matching_phone_number(
     try:
         cand_phone = phonenumbers.parse(candidate_props["phone_number"], "US")
     except phonenumbers.NumberParseException:
-        logger.warning("Invalid candidate phone number for location %s: %s", <an_id_field>, candidate_props["phone_number"])
+        logger.warning(
+            "Invalid candidate phone number for location %s: %s",
+            candidate_props["id"],
+            candidate_props["phone_number"],
+        )
         return None
 
     src_phones = []
@@ -121,7 +125,11 @@ def has_matching_phone_number(
         try:
             src_phones.append(phonenumbers.parse(contact.phone, "US"))
         except phonenumbers.NumberParseException:
-            logger.warning("Invalid source phone number for location %s: %s", source.id, contact.phone)
+            logger.warning(
+                "Invalid source phone number for location %s: %s",
+                source.id,
+                contact.phone,
+            )
             continue
 
     if not src_phones:

--- a/vaccine_feed_ingest/utils/normalize.py
+++ b/vaccine_feed_ingest/utils/normalize.py
@@ -7,6 +7,11 @@ from typing import Optional, Tuple
 import url_normalize
 from vaccine_feed_ingest_schema.location import VaccineProvider
 
+from .log import getLogger
+
+logger = getLogger(__file__)
+
+
 # Add to this list in alphabetical order
 VACCINE_PROVIDER_REGEXES = {
     VaccineProvider.ACME: [

--- a/vaccine_feed_ingest/utils/parse.py
+++ b/vaccine_feed_ingest/utils/parse.py
@@ -3,6 +3,10 @@ Utilities for the parse step
 """
 import re
 
+from .log import getLogger
+
+logger = getLogger(__file__)
+
 
 def location_id_from_name(name: str) -> str:
     """Get a stable ID for a location from its name.


### PR DESCRIPTION
1. Move address similarity to helper, and allow for slight differences for a match to count.
2. If providers are available then block matching if providers are dissimilar
3.  If phone numbers are available then block matching if phone numbers are dissimilar

This does not include the promised address matching improvements because I am still figuring out how to make them work on dirty addresses.