### PR TITLE
Improve concordance matching mainly by skipping those with underscores

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,7 +75,7 @@ def full_location():
         links=[
             location.Link(
                 authority=location.LocationAuthority.GOOGLE_PLACES,
-                id="abc123",
+                id="ChIJA0MOOYWHj4ARW8M-vrC9yGA",
             ),
         ],
         notes=["long note goes here"],

--- a/tests/utils/test_match.py
+++ b/tests/utils/test_match.py
@@ -1,6 +1,12 @@
 from vaccine_feed_ingest.utils import match
 
 
+def test_is_concordance_similar(full_location, minimal_location, vial_location):
+    assert match.is_concordance_similar(full_location, vial_location)
+
+    assert not match.is_concordance_similar(minimal_location, vial_location)
+
+
 def test_is_address_similar(full_location, minimal_location, vial_location):
     assert match.is_address_similar(full_location, vial_location)
 


### PR DESCRIPTION
1. Skips tag concordances: those that start with _
2. Skips matching conflicting concordances like locations with different google places ids

This is the prerequisite to adding "provider tags" to concordances