### PR TITLE
Relax phone number exclusion to only mismatch by area code

### DIFF
--- a/tests/utils/test_match.py
+++ b/tests/utils/test_match.py
@@ -19,7 +19,7 @@ def test_is_provider_similar(full_location, minimal_location, vial_location):
     assert not match.is_provider_similar(minimal_location, vial_location)
 
 
-def test_has_matching_phone_number(full_location, minimal_location, vial_location):
-    assert match.has_matching_phone_number(full_location, vial_location)
+def test_is_phone_number_similar(full_location, minimal_location, vial_location):
+    assert match.is_phone_number_similar(full_location, vial_location)
 
-    assert not match.has_matching_phone_number(minimal_location, vial_location)
+    assert not match.is_phone_number_similar(minimal_location, vial_location)

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -14,9 +14,9 @@ from vaccine_feed_ingest.utils.log import getLogger
 
 from .. import vial
 from ..utils.match import (
-    has_matching_phone_number,
     is_address_similar,
     is_concordance_similar,
+    is_phone_number_similar,
     is_provider_similar,
 )
 from . import outputs
@@ -296,7 +296,7 @@ def _is_match(source: location.NormalizedLocation, candidate: dict) -> bool:
         return False
 
     # If there are phone numbers and the phone numbers don't match then fail to match
-    phone_matches = has_matching_phone_number(source, candidate)
+    phone_matches = is_phone_number_similar(source, candidate)
     if phone_matches is not None and phone_matches is False:
         return False
 

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -43,6 +43,9 @@ def load_sites_to_vial(
     with vial.vial_client(vial_server, vial_apikey) as vial_http:
         import_run_id = vial.start_import_run(vial_http)
 
+        locations = None
+        matched_ids = None
+
         if enable_match or enable_create:
             logger.info("Loading existing location from VIAL")
             locations = vial.retrieve_existing_locations_as_index(vial_http)

--- a/vaccine_feed_ingest/utils/match.py
+++ b/vaccine_feed_ingest/utils/match.py
@@ -180,8 +180,8 @@ def is_phone_number_similar(
     """Compares phone numbers by area code
 
     - True if has at least one matching phone number
-    - False is mismatching phone numbers within the same area code
-    - None if no valid phone numbers to compare
+    - False if mismatching phone numbers within the same area code
+    - None if no valid phone numbers to compare, or valid phone numbers are in different area codes
     """
     candidate_props = candidate.get("properties", {})
 


### PR DESCRIPTION
I am trying to handle the case were these two confirmed **different** clinics have the same address, but a different phone number:
1. "The Little Clinic": https://vial-staging.calltheshots.us/admin/core/location/19179/change/
2. "Kroger": https://vial-staging.calltheshots.us/admin/core/location/18821/change/

Previously I skipped matching if phone numbers differed, but it is common for locations to have a 800 number and a location number and for different feeds to use different ones.

This relaxes the exclusion rule to only compare phone numbers with the same area code. This should hopefully still skip  merging "The Little Clinics" while still getting locations with different numbers in each feed.