### PR TITLE
Normalize phone number format if possible to (###) ###-#### ext. #####

### DIFF
--- a/tests/stages/test_enrichment.py
+++ b/tests/stages/test_enrichment.py
@@ -1,3 +1,5 @@
+from vaccine_feed_ingest_schema import location
+
 from vaccine_feed_ingest.stages import enrichment
 
 
@@ -28,3 +30,26 @@ def test_add_source_link(full_location):
     links = enrichment._generate_link_map(full_location)
     assert full_location.source.source in links
     assert links[full_location.source.source] == full_location.source.id
+
+
+def test_normalize_phone_format(minimal_location):
+    minimal_location.contact = [
+        location.Contact(phone="(800) 456-7890"),
+        location.Contact(phone="1-415-789-3456"),
+        location.Contact(phone="+1 (415)888-8888"),
+        location.Contact(phone="888-888-8888 x8888888888"),
+    ]
+
+    enrichment._normalize_phone_format(minimal_location)
+
+    assert len(minimal_location.contact) == 4
+
+    expected = {
+        "(800) 456-7890",
+        "(415) 789-3456",
+        "(415) 888-8888",
+        "888-888-8888 x8888888888",
+    }
+    actual = {entry.phone for entry in minimal_location.contact if entry.phone}
+
+    assert expected == actual


### PR DESCRIPTION
If `phonenumbers` can parse the phone number, then normalize it to the "national" format `(###) ###-#### ext. #####`.

If it cannot parse it then leave it as-is.