### PR TITLE
Fetch utah.gov for UT

### DIFF
--- a/vaccine_feed_ingest/runners/ut/state/fetch.sh
+++ b/vaccine_feed_ingest/runners/ut/state/fetch.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+output_dir=""
+
+if [ -n "${1}" ]; then
+    output_dir="${1}"
+else
+    echo "Must pass an output_dir as first argument"
+fi
+
+(cd "$output_dir" && curl --silent 'https://coronavirus.utah.gov/vaccine-distribution/' -o 'ut-gov.html')


### PR DESCRIPTION
# <!-- <stage> <site> for <state> (e.g.,  Normalize ArcGIS for MD) -->

| Key Details |
|-|
| Resolves #533  |
State: UT |
Site: coronavirus.utah.gov/vaccine-distribution/ |

## Notes
<!-- Share any information which would be helpful to the reviewer -->
This is straight up the `html` page (is this even _right?_).

Essentially the page has links to other websites and various phone numbers but no address readily accessible, even when going through some of the website. 

Since it seems like info will be missing once this goes through the pipeline, is this diverted to web banking?

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```html

<!DOCTYPE html>

<html class="no-js" lang="en-US">

<head>
  
<meta charset="UTF-8">
<meta name="viewport" content="width=device-width, initial-scale=1.0">
<link rel="pingback" href="https://coronavirus.utah.gov/xmlrpc.php">
<title>Vaccine Distribution | coronavirus</title>
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`

:)
```  
lint-fix: commands succeeded
  congratulations :)
```