### PR TITLE
Add fetch step for wa/state. Fixes #479

### DIFF
--- a/vaccine_feed_ingest/runners/wa/state/fetch.py
+++ b/vaccine_feed_ingest/runners/wa/state/fetch.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+import requests
+
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
+
+
+# See https://apim-vaccs-prod.azure-api.net/web/graphql for the full interface w/documention
+QUERY = """
+{
+  searchLocations(
+    searchInput: {
+      # Area of Washinton State
+      radiusMiles: 71362
+      # A very large paging size
+      paging: { pageSize: 1000000, pageNum: 1 }
+    }
+  ) {
+    paging {
+      total
+      pageNum
+      pageSize
+    }
+    locations {
+      locationId
+      locationName
+      locationType
+      providerId
+      providerName
+      departmentId
+      departmentName
+      addressLine1
+      addressLine2
+      city
+      state
+      county
+      zipcode
+      latitude
+      longitude
+      description
+      contactFirstName
+      contactLastName
+      fax
+      phone
+      email
+      schedulingLink
+      vaccineAvailability
+      infoLink
+      timeZoneId
+      directions
+      updatedAt
+      rawDataSourceName
+      vaccineTypes
+      accessibleParking
+      additionalSupports
+      commCardAvailable
+      commCardBrailleAvailable
+      driveupSite
+      interpretersAvailable
+      interpretersDesc
+      supportUrl
+      waitingArea
+      walkupSite
+      wheelchairAccessible
+      scheduleOnline
+      scheduleByPhone
+      scheduleByEmail
+      walkIn
+      waitList
+    }
+    summary {
+      vaccineAvailability
+      total
+    }
+  }
+}
+"""
+
+GRAPHQL_ENDPOINT = "https://apim-vaccs-prod.azure-api.net/web/graphql"
+
+output_dir = sys.argv[1]
+if output_dir is None:
+    logger.error("Must pass an output_dir as first argument")
+    sys.exit(1)
+
+r = requests.post(GRAPHQL_ENDPOINT, json={"query": QUERY})
+file = open(os.path.join(output_dir, "output.json"), "w")
+file.write(r.text)
+file.close()

--- a/vaccine_feed_ingest/runners/wa/state/fetch.py
+++ b/vaccine_feed_ingest/runners/wa/state/fetch.py
@@ -10,6 +10,7 @@ logger = getLogger(__file__)
 
 
 # See https://apim-vaccs-prod.azure-api.net/web/graphql for the full interface w/documention
+# editorconfig-checker-disable
 QUERY = """
 {
   searchLocations(
@@ -79,6 +80,7 @@ QUERY = """
   }
 }
 """
+# editorconfig-checker-enable
 
 GRAPHQL_ENDPOINT = "https://apim-vaccs-prod.azure-api.net/web/graphql"
 


### PR DESCRIPTION
# Fetch State for WA

| Key Details |
|-|
| Resolves #479 |
State: WA |
Site: state |

## Notes
Very convenient graphql API with self documented interface. Seemed fine to grab it all in one page. About 2k results when I tested it out.

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```json
{"data":{"searchLocations":{"paging":{"total":1921,"pageNum":1,"pageSize":1000000},"locations":[{"locationId":"recT5VYLb0qwyVTSz","locationName":"North Basin - Davenport","locationType":null,"providerId":null,"providerName":null,"departmentId":null,"departmentName":null,"addressLine1":"100 3rd Street","addressLine2":null,"city":"Davenport","state":"Washington","county":"Lincoln","zipcode":"99122","latitude":47.65713,"longitude":-118.14546,"description":null,"contactFirstName":null,"contactLastName":null,"fax":null,"phone":"(509) 725-7501","email":null,"schedulingLink":"https://www.lincolnhospital.org/health-resources/covid-19-update/","vaccineAvailability":"AVAILABLE","infoLink":null,"timeZoneId":null,"directions":"We are currently scheduling weekly vaccine clinics based on the number of vaccines we receive and individual eligibility. The clinics are by appointment only.\n\nPlease call 509.725.7501 and ask to be added to our wait-list. Please note that the vaccine is still available in limited quantities and our demand is higher than our current supply. We will do the best we can to get your scheduled as quickly as possible.","updatedAt":"2021-05-08T17:58:06.647Z","rawDataSourceName":"CovidWaFn","vaccineTypes":[],"accessibleParking":null,"additionalSupports":null,"commCardAvailable":null,"commCardBrailleAvailable":null,"driveupSite":null,"interpretersAvailable":null,"interpretersDesc":null,"supportUrl":null,"waitingArea":null,"walkupSite":null,"wheelchairAccessible":null,"scheduleOnline":null,"scheduleByPhone":null,"scheduleByEmail":null,"walkIn":null,"waitList":null},{"locationId":"recmLmhezm8iIK6t0","locationName":"Valley View Health Center - Winlock","locationType":null,"providerId":null,"providerName":null,"departmentId":nu ...
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
