### PR TITLE
ISSUE-405: Add ia/state parser

### DIFF
--- a/vaccine_feed_ingest/runners/ia/state/parse.py
+++ b/vaccine_feed_ingest/runners/ia/state/parse.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+OUTPUT_DIR = pathlib.Path(sys.argv[1])
+INPUT_DIR = pathlib.Path(sys.argv[2])
+
+
+def zip_infile_outfile_pairs(input_dir, output_dir):
+    infile_paths = input_dir.glob("*.json")
+    for infile_path in infile_paths:
+        filename = infile_path.stem
+        outfile_path = output_dir.joinpath(f"{filename}.parsed.ndjson")
+        yield infile_path, outfile_path
+
+
+def main(argv):
+    output_dir = pathlib.Path(argv[1])
+    input_dir = pathlib.Path(argv[2])
+
+    for infile_path, outfile_path in zip_infile_outfile_pairs(input_dir, output_dir):
+        with open(infile_path, "r") as fin:
+            contents = json.load(fin)
+            # The raw file encodes each record as a string instead of a structured json, so we need a
+            # second round of deserialization
+            records = json.loads(contents["Result"])
+        with open(outfile_path, "w") as fout:
+            for record in records:
+                json.dump(record, fout)
+                fout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
# Parse State for IA

| Key Details |
|-|
| Resolves #405  |
State: ia |
Site: state |

## Notes
This commit adds a python ia/state parser. Couldn't use the shared
json parser because each record was encoded as a string instead of structured
json.

## Data sample
```json
{"MilesAway": 0.0, "Distance": 175.5, "StartingLat": "42.03205000", "StartingLng": "-93.59139000", "ProviderID": 147, "ProviderName": "Wagner Pharmacy", "Phone": "(563) 242-0626", "Address1": "1726 N. 2nd Street", "City": "Clinton", "State": "IA", "Zipcode": "52732", "County": "", "websiteurl": "https://www.wagnerpharmacies.com", "WebpageSurveyResponse": "", "ActiveFlag": true, "LatCoord": "41.86476", "LngCoord": "-90.18307", "CreatedBy": "", "CreateDate": null, "ModifiedBy": "", "ModifyDate": null}
{"MilesAway": 0.0, "Distance": 175.4, "StartingLat": "42.03205000", "StartingLng": "-93.59139000", "ProviderID": 144, "ProviderName": "Clinton County Public Health- Genesis VNA", "Phone": "(563) 242-7165 #3", "Address1": "611 N 2nd St", "City": "Clinton", "State": "IA", "Zipcode": "52732", "County": "", "websiteurl": "", "WebpageSurveyResponse": "", "ActiveFlag": true, "LatCoord": "41.85034", "LngCoord": "-90.18707", "CreatedBy": "", "CreateDate": null, "ModifiedBy": "", "ModifyDate": null}
{"MilesAway": 0.0, "Distance": 175.4, "StartingLat": "42.03205000", "StartingLng": "-93.59139000", "ProviderID": 307, "ProviderName": "Jackson County Board of Health/Public Health", "Phone": "(563) 242-7165 #3", "Address1": "611 N 2nd St", "City": "Clinton", "State": "IA", "Zipcode": "52732", "County": "", "websiteurl": "", "WebpageSurveyResponse": "", "ActiveFlag": true, "LatCoord": "41.85034", "LngCoord": "-90.18707", "CreatedBy": "", "CreateDate": null, "ModifiedBy": "", "ModifyDate": null}
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
