### PR TITLE
Normalize ArcGIS for SD

### DIFF
--- a/vaccine_feed_ingest/runners/sd/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/sd/arcgis/normalize.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+
+import datetime
+import json
+import os
+import pathlib
+import re
+import sys
+from typing import List, Optional
+
+from vaccine_feed_ingest_schema import location as schema
+
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
+
+
+def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:
+    contacts = []
+    if site["attributes"]["phone"]:
+        sourcePhone = re.sub("[^0-9]", "", site["attributes"]["phone"])
+        if len(sourcePhone) == 11:
+            sourcePhone = sourcePhone[1:]
+        phone = f"({sourcePhone[0:3]}) {sourcePhone[3:6]}-{sourcePhone[6:]}"
+        contacts.append(schema.Contact(phone=phone))
+
+    if site["attributes"]["email"]:
+        contacts.append(schema.Contact(email=site["attributes"]["email"]))
+
+    if site["attributes"]["agencyurl"]:
+        contacts.append(schema.Contact(website=site["attributes"]["agencyurl"]))
+
+    if len(contacts):
+        return contacts
+
+    return None
+
+
+def _get_id(site: dict) -> str:
+    data_id = site["attributes"]["GlobalID"]
+
+    # Could parse these from directory traversal, but do not for now to avoid
+    # accidental mutation.
+    site_name = "arcgis"
+    runner = "sd"
+
+    # Could parse these from the input file name, but do not for now to avoid
+    # accidental mutation.
+    arcgis = "3bb3f167d57149ef8027a68a609edc2d"
+    layer = 0
+
+    return f"{runner}_{site_name}:{arcgis}_{layer}_{data_id}"
+
+
+def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLocation:
+    return schema.NormalizedLocation(
+        id=_get_id(site),
+        name=site["attributes"]["name"],
+        address=schema.Address(
+            street1=site["attributes"]["fulladdr"],
+            city=site["attributes"]["municipality"],
+            state="SD",
+            zip=None,  # Not available in the data. :(
+        ),
+        location=schema.LatLng(
+            latitude=site["geometry"]["y"],
+            longitude=site["geometry"]["x"],
+        ),
+        contact=_get_contacts(site),
+        languages=None,
+        opening_dates=None,
+        opening_hours=None,
+        availability=None,
+        inventory=None,
+        access=None,
+        parent_organization=None,
+        links=None,
+        notes=None,
+        active=None,
+        source=schema.Source(
+            source="sd_arcgis",
+            id=site["attributes"]["GlobalID"],
+            fetched_from_uri="https://sdbit.maps.arcgis.com/apps/instant/nearby/index.html?appid=04a23bbd90aa4eeb9c454c303a5c2f06",
+            fetched_at=timestamp,
+            published_at=timestamp,  # No publication date in the data.
+            data=site,
+        ),
+    )
+
+
+output_dir = pathlib.Path(sys.argv[1])
+input_dir = pathlib.Path(sys.argv[2])
+
+json_filepaths = input_dir.glob("*.ndjson")
+
+parsed_at_timestamp = datetime.datetime.utcnow().isoformat()
+
+for in_filepath in json_filepaths:
+    filename, _ = os.path.splitext(in_filepath.name)
+    out_filepath = output_dir / f"{filename}.normalized.ndjson"
+
+    logger.info(
+        "normalizing %s => %s",
+        in_filepath,
+        out_filepath,
+    )
+
+    with in_filepath.open() as fin:
+        with out_filepath.open("w") as fout:
+            for site_json in fin:
+                parsed_site = json.loads(site_json)
+
+                normalized_site = _get_normalized_location(
+                    parsed_site, parsed_at_timestamp
+                )
+
+                json.dump(normalized_site.dict(), fout)
+                fout.write("\n")


### PR DESCRIPTION
# <!-- <stage> <site> for <state> (e.g.,  Normalize ArcGIS for MD) -->

| Key Details |
|-|
| Resolves #526  |
State: SD |
Site: arcgis |

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```json
{"id": "sd_arcgis:3bb3f167d57149ef8027a68a609edc2d_0_4dd5c027-89c2-4644-91fa-e48245a109c3", "name": "WALMART PHARMACY #3853", "address": {"street1": "2791 DAKOTA AVE S", "street2": null, "city": "HURON", "state": "SD", "zip": null}, "location": {"latitude": 44.33447799999999, "longitude": -98.214367}, "contact": [{"contact_type": null, "phone": null, "website": "https://www.walmart.com/cp/1228302", "email": null, "other": null}], "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": null, "active": null, "source": {"source": "sd_arcgis", "id": "4dd5c027-89c2-4644-91fa-e48245a109c3", "fetched_from_uri": "https://sdbit.maps.arcgis.com/apps/instant/nearby/index.html?appid=04a23bbd90aa4eeb9c454c303a5c2f06", "fetched_at": "2021-05-10T08:07:46.561619", "published_at": "2021-05-10T08:07:46.561619", "data": {"attributes": {"EditDate": null, "GlobalID": "4dd5c027-89c2-4644-91fa-e48245a109c3", "OBJECTID": 464, "acceptsinsurance": null, "agencyurl": "https://www.walmart.com/cp/1228302", "comments": null, "email": null, "facebook": null, "facilityarea": null, "facilityid": null, "factype": "Pharmacy", "fulladdr": "2791 DAKOTA AVE S", "imageurl": null, "instagram": null, "layer_id": 0, "municipality": "HURON", "name": "WALMART PHARMACY #3853", "operhours": null, "phone": null, "pubview": "Yes", "service_item_id": "3bb3f167d57149ef8027a68a609edc2d", "status": null, "twitter": null, "waittime": null, "walkins": null}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -98.214367, "y": 44.33447799999999}}}}
```

## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
