### PR TITLE
Add pipeline for ma/ma_immunizations

### DIFF
--- a/vaccine_feed_ingest/runners/_shared/fetch.py
+++ b/vaccine_feed_ingest/runners/_shared/fetch.py
@@ -63,11 +63,13 @@ if "parser" not in config or config["parser"] == "arcgis":
 elif config["parser"] == "prepmod":
     try:
         base_url = urllib.parse.urljoin(config["url"], "appointment/en/clinic/search")
+        headers = config.get("headers") or {}
+        extra_params = config.get("params") or {}
         page = 1
         while True:
-            params = urllib.parse.urlencode({"page": page})
+            params = urllib.parse.urlencode(extra_params | {"page": page})
             url = f"{base_url}?{params}"
-            response = requests.get(url, allow_redirects=False)
+            response = requests.get(url, allow_redirects=False, headers=headers)
 
             # when out of results, will return 302
             if response.status_code != 200:

--- a/vaccine_feed_ingest/runners/ma/ma_immunizations/fetch.yml
+++ b/vaccine_feed_ingest/runners/ma/ma_immunizations/fetch.yml
@@ -1,0 +1,9 @@
+---
+state: ma
+site: ma_immunizations
+parser: prepmod
+url: https://www.maimmunizations.org
+params:
+  q[venue_search_name_or_venue_name_i_cont]: ''
+headers:
+  User-Agent: github.com/CAVaccineInventory

--- a/vaccine_feed_ingest/runners/ma/ma_immunizations/fetch.yml
+++ b/vaccine_feed_ingest/runners/ma/ma_immunizations/fetch.yml
@@ -6,4 +6,4 @@ url: https://www.maimmunizations.org
 params:
   q[venue_search_name_or_venue_name_i_cont]: ''
 headers:
-  User-Agent: github.com/CAVaccineInventory
+  User-Agent: Vaccinebot (+https://www.vaccinatethestates.com/vaccinebot)

--- a/vaccine_feed_ingest/runners/ma/ma_immunizations/normalize.yml
+++ b/vaccine_feed_ingest/runners/ma/ma_immunizations/normalize.yml
@@ -1,0 +1,5 @@
+---
+state: ma
+site: ma_immunizations
+parser: prepmod
+url: https://www.maimmunizations.org

--- a/vaccine_feed_ingest/runners/ma/ma_immunizations/parse.yml
+++ b/vaccine_feed_ingest/runners/ma/ma_immunizations/parse.yml
@@ -1,0 +1,4 @@
+---
+state: ma
+site: ma_immunizations
+parser: prepmod


### PR DESCRIPTION
# ma/ma_immunizations

| Key Details |
|-|
| Resolves #241 |
| Resolves #242 |
| Resolves #243 |
State: ma |
Site: ma_immunizations |

## Notes
I had to make a few tweaks to the prepmod infra to get this to work.
- Added support for extra params.  The site returns empty results if that `q[...]` param is missing, for some reason.
- Added support for headers.  The site seems to have some relatively naive bot checking.  It 403's with empty user agent, but will allow anything else in, e.g. `curl` worked just fine in my local testing.  Used the URL for this github as a fill-in, but let me know if there's a more official UA / good netizen convention for this project.

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```json
{"id": "ma_immunizations:4573", "name": "Greenfield Senior Center", "address": {"street1": "35 Pleasant Street", "street2": null, "city": "Greenfield", "state": "MA", "zip": "01301"}, "location": null, "contact": [{"contact_type": "booking", "phone": null, "website": "https://www.maimmunizations.org/appointment/en/client/registration?clinic_id=4573", "email": null, "other": null}], "languages": null, "opening_dates": [{"opens": "2021-05-12", "closes": "2021-05-12"}], "opening_hours": [{"day": "wednesday", "opens": "11:00", "closes": "18:00"}], "availability": {"drop_in": null, "appointments": true}, "inventory": [{"vaccine": "moderna", "supply_level": null}], "access": null, "parent_organization": null, "links": null, "notes": ["", "If you are signing up for a second dose, you must get the same vaccine brand as your first dose."], "active": null, "source": {"source": "ma_immunizations", "id": "4573", "fetched_from_uri": "https://www.maimmunizations.org/clinic/search", "fetched_at": "2021-05-11T11:46:24.179337", "published_at": null, "data": {"name": "Greenfield Senior Center", "date": "05/12/2021", "address": "35 Pleasant Street, Greenfield MA, 01301", "vaccines": "Moderna COVID-19 Vaccine", "ages": "Adults, Seniors", "info": "", "hours": "11:00 am - 06:00 pm", "available": "0", "special": "If you are signing up for a second dose, you must get the same vaccine brand as your first dose.", "clinic_id": "4573"}}}
{"id": "ma_immunizations:4623", "name": "Saint Vincent Hospital Vaccine Collaborative @ Worcester State University - Wellness Center", "address": {"street1": "525 Chandler Street", "street2": null, "city": "Worcester", "state": "MA", "zip": "01602"}, "location": null, "contact": [{"contact_type": "booking", "phone": null, "website": "https://www.maimmunizations.org/appointment/en/client/registration?clinic_id=4623", "email": null, "other": null}], "languages": null, "opening_dates": [{"opens": "2021-05-12", "closes": "2021-05-12"}], "opening_hours": [{"day": "wednesday", "opens": "13:30", "closes": "17:30"}], "availability": {"drop_in": null, "appointments": true}, "inventory": [{"vaccine": "pfizer_biontech", "supply_level": null}], "access": null, "parent_organization": null, "links": null, "notes": ["By Appointment Only - Arrive 15min before scheduled appointment.\n\nDo not enter the building until 5 min before your scheduled appt time. Watch the digital scoreboard for appointment time prompting.\n\nBRING PHOTO ID AND INSURANCE CARD(S).\n\nMASKS are required and must be worn properly at all times.\n\nIf receiving your 2nd dose, please bring your vaccine card with you.\n\nWear clothing that allows a clinician to easily access your upper arm. The vaccine is delivered to the deltoid muscle, the big muscle on your shoulder. Consider wearing a short-sleeved shirt, or wear a short-sleeved shirt under a sweater or jacket that can be easily removed.\n\n***We kindly request that you do not bring children to the vaccination clinic site***", "If you are signing up for a second dose, you must get the same vaccine brand as your first dose."], "active": null, "source": {"source": "ma_immunizations", "id": "4623", "fetched_from_uri": "https://www.maimmunizations.org/clinic/search", "fetched_at": "2021-05-11T11:46:24.179337", "published_at": null, "data": {"name": "Saint Vincent Hospital Vaccine Collaborative @ Worcester State University - Wellness Center", "date": "05/12/2021", "address": "525 Chandler Street, Worcester MA, 01602", "vaccines": "Pfizer-BioNTech COVID-19 Vaccine", "ages": "Adults, Seniors, Other", "info": "By Appointment Only - Arrive 15min before scheduled appointment.\n\nDo not enter the building until 5 min before your scheduled appt time. Watch the digital scoreboard for appointment time prompting.\n\nBRING PHOTO ID AND INSURANCE CARD(S).\n\nMASKS are required and must be worn properly at all times.\n\nIf receiving your 2nd dose, please bring your vaccine card with you.\n\nWear clothing that allows a clinician to easily access your upper arm. The vaccine is delivered to the deltoid muscle, the big muscle on your shoulder. Consider wearing a short-sleeved shirt, or wear a short-sleeved shirt under a sweater or jacket that can be easily removed.\n\n***We kindly request that you do not bring children to the vaccination clinic site***", "hours": "01:30 pm - 05:30 pm", "available": "592", "special": "If you are signing up for a second dose, you must get the same vaccine brand as your first dose.", "clinic_id": "4623"}}}
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
