### PR TITLE
Impose a max source location record size of 15KB and fix vaccinespotter

### DIFF
--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -67,6 +67,17 @@ def _sites_argument() -> Callable:
     return click.argument("sites", nargs=-1, type=str)
 
 
+def _exclude_sites_option() -> Callable:
+    return click.option(
+        "--exclude-sites",
+        type=str,
+        default=lambda: os.environ.get("EXCLUDE_SITES", ""),
+        callback=lambda ctx, param, value: set(
+            [item.strip().lower() for item in value.split(",")]
+        ),
+    )
+
+
 def _stages_option() -> Callable:
     return click.option(
         "--stages",
@@ -221,12 +232,14 @@ def _compute_has_parse(site_dir: pathlib.Path) -> bool:
 
 @cli.command()
 @_sites_argument()
+@_exclude_sites_option()
 @_state_option()
 @_output_dir_option()
 @_dry_run_option()
 @_fail_on_error_option()
 def fetch(
     sites: Optional[Sequence[str]],
+    exclude_sites: Optional[Collection[str]],
     state: Optional[str],
     output_dir: pathlib.Path,
     dry_run: bool,
@@ -234,7 +247,7 @@ def fetch(
 ) -> None:
     """Run fetch process for specified sites."""
     timestamp = _generate_run_timestamp()
-    site_dirs = site.get_site_dirs(state, sites)
+    site_dirs = site.get_site_dirs(state, sites, exclude_sites)
 
     for site_dir in site_dirs:
         ingest.run_fetch(
@@ -248,6 +261,7 @@ def fetch(
 
 @cli.command()
 @_sites_argument()
+@_exclude_sites_option()
 @_state_option()
 @_output_dir_option()
 @_dry_run_option()
@@ -255,6 +269,7 @@ def fetch(
 @_fail_on_error_option()
 def parse(
     sites: Optional[Sequence[str]],
+    exclude_sites: Optional[Collection[str]],
     state: Optional[str],
     output_dir: pathlib.Path,
     dry_run: bool,
@@ -263,7 +278,7 @@ def parse(
 ) -> None:
     """Run parse process for specified sites."""
     timestamp = _generate_run_timestamp()
-    site_dirs = site.get_site_dirs(state, sites)
+    site_dirs = site.get_site_dirs(state, sites, exclude_sites)
 
     for site_dir in site_dirs:
         ingest.run_parse(
@@ -278,6 +293,7 @@ def parse(
 
 @cli.command()
 @_sites_argument()
+@_exclude_sites_option()
 @_state_option()
 @_output_dir_option()
 @_dry_run_option()
@@ -285,6 +301,7 @@ def parse(
 @_fail_on_error_option()
 def normalize(
     sites: Optional[Sequence[str]],
+    exclude_sites: Optional[Collection[str]],
     state: Optional[str],
     output_dir: pathlib.Path,
     dry_run: bool,
@@ -293,7 +310,7 @@ def normalize(
 ) -> None:
     """Run normalize process for specified sites."""
     timestamp = _generate_run_timestamp()
-    site_dirs = site.get_site_dirs(state, sites)
+    site_dirs = site.get_site_dirs(state, sites, exclude_sites)
 
     for site_dir in site_dirs:
         ingest.run_normalize(
@@ -308,18 +325,20 @@ def normalize(
 
 @cli.command()
 @_sites_argument()
+@_exclude_sites_option()
 @_state_option()
 @_output_dir_option()
 @_fail_on_error_option()
 def all_stages(
     sites: Optional[Sequence[str]],
+    exclude_sites: Optional[Collection[str]],
     state: Optional[str],
     output_dir: pathlib.Path,
     fail_on_runner_error: bool,
 ) -> None:
     """Run all stages in succession for specified sites."""
     timestamp = _generate_run_timestamp()
-    site_dirs = site.get_site_dirs(state, sites)
+    site_dirs = site.get_site_dirs(state, sites, exclude_sites)
 
     for site_dir in site_dirs:
         fetch_success = ingest.run_fetch(
@@ -343,18 +362,20 @@ def all_stages(
 
 @cli.command()
 @_sites_argument()
+@_exclude_sites_option()
 @_state_option()
 @_output_dir_option()
 @_dry_run_option()
 def enrich(
     sites: Optional[Sequence[str]],
+    exclude_sites: Optional[Collection[str]],
     state: Optional[str],
     output_dir: pathlib.Path,
     dry_run: bool,
 ) -> None:
     """Run enrich process for specified sites."""
     timestamp = _generate_run_timestamp()
-    site_dirs = site.get_site_dirs(state, sites)
+    site_dirs = site.get_site_dirs(state, sites, exclude_sites)
 
     for site_dir in site_dirs:
         ingest.run_enrich(site_dir, output_dir, timestamp, dry_run)
@@ -362,6 +383,7 @@ def enrich(
 
 @cli.command()
 @_sites_argument()
+@_exclude_sites_option()
 @_state_option()
 @_output_dir_option()
 @_dry_run_option()
@@ -376,6 +398,7 @@ def enrich(
 @_import_batch_size_option()
 def load_to_vial(
     sites: Optional[Sequence[str]],
+    exclude_sites: Optional[Collection[str]],
     state: Optional[str],
     output_dir: pathlib.Path,
     dry_run: bool,
@@ -390,7 +413,7 @@ def load_to_vial(
     import_batch_size: int,
 ) -> None:
     """Load specified sites to vial server."""
-    site_dirs = site.get_site_dirs(state, sites)
+    site_dirs = site.get_site_dirs(state, sites, exclude_sites)
 
     if match_ids and create_ids:
         conflicting_ids = set(match_ids.keys()) & set(create_ids)
@@ -417,6 +440,7 @@ def load_to_vial(
 
 @cli.command()
 @_sites_argument()
+@_exclude_sites_option()
 @_state_option()
 @_output_dir_option()
 @_dry_run_option()
@@ -433,6 +457,7 @@ def load_to_vial(
 @_fail_on_error_option()
 def pipeline(
     sites: Optional[Sequence[str]],
+    exclude_sites: Optional[Collection[str]],
     state: Optional[str],
     output_dir: pathlib.Path,
     dry_run: bool,
@@ -450,7 +475,7 @@ def pipeline(
 ) -> None:
     """Run all stages in succession for specified sites."""
     timestamp = _generate_run_timestamp()
-    site_dirs = site.get_site_dirs(state, sites)
+    site_dirs = site.get_site_dirs(state, sites, exclude_sites)
 
     sites_to_load = []
 

--- a/vaccine_feed_ingest/runners/us/vaccinespotter_org/normalize.py
+++ b/vaccine_feed_ingest/runners/us/vaccinespotter_org/normalize.py
@@ -60,6 +60,14 @@ def _get_lat_lng(geometry: dict, id: str) -> Optional[schema.LatLng]:
     return None
 
 
+def _strip_source_data(site_blob: dict) -> None:
+    """Strip out fields which make the source blob too big to store"""
+    # Remove list of all available appoitments times. We are not using this information
+    # and it makes each record 65K+
+    if site_blob.get("properties") and site_blob["properties"].get("appointments"):
+        del site_blob["properties"]["appointments"]
+
+
 def normalize(site_blob: dict, timestamp: str) -> dict:
     site = site_blob["properties"]
 
@@ -72,6 +80,8 @@ def normalize(site_blob: dict, timestamp: str) -> dict:
         links.append(
             schema.Link(authority=parsed_provider_link[0], id=parsed_provider_link[1])
         )
+
+    _strip_source_data(site_blob)
 
     return schema.NormalizedLocation(
         id=f"vaccinespotter_org:{site['id']}",

--- a/vaccine_feed_ingest/stages/ingest.py
+++ b/vaccine_feed_ingest/stages/ingest.py
@@ -391,7 +391,7 @@ def _validate_normalized(output_dir: pathlib.Path) -> bool:
     ):
         with filepath.open() as ndjson_file:
             for line_no, content in enumerate(ndjson_file):
-                if len(content) > MAX_NORMALIZED_RECORD_SIZE):
+                if len(content) > MAX_NORMALIZED_RECORD_SIZE:
                     logger.warning(
                         "Source location too large to process in %s at line %d: %s",
                         filepath,

--- a/vaccine_feed_ingest/stages/site.py
+++ b/vaccine_feed_ingest/stages/site.py
@@ -2,7 +2,7 @@
 
 import os
 import pathlib
-from typing import Iterator, Optional, Sequence, Tuple
+from typing import Collection, Iterator, Optional, Sequence, Tuple
 
 from vaccine_feed_ingest.utils.log import getLogger
 
@@ -35,7 +35,9 @@ def get_site_dir(site: str) -> Optional[pathlib.Path]:
 
 
 def get_site_dirs(
-    state: Optional[str], sites: Optional[Sequence[str]]
+    state: Optional[str],
+    sites: Optional[Sequence[str]],
+    exclude_sites: Optional[Collection[str]],
 ) -> Iterator[pathlib.Path]:
     """Return a site directory path, if it exists"""
     if sites:
@@ -47,7 +49,13 @@ def get_site_dirs(
             yield site_dir
 
     else:
-        yield from get_site_dirs_for_state(state)
+        for site_dir in get_site_dirs_for_state(state):
+            site_name = str(site_dir.relative_to(RUNNERS_DIR))
+
+            if exclude_sites and site_name in exclude_sites:
+                continue
+
+            yield site_dir
 
 
 def find_relevant_file(


### PR DESCRIPTION
`vaccinespotter_org` had 65KB+ record sizes because they have every appointment time available as a huge list! This was causing import to fail because the post body was too big.

We aren't using this information anywhere so I am stripping it out of the `source.data` field in the `normalize` stage. If we want to use this data in the future we can add it back as a normalized field.

I also added the ability to exclude sites when processing so I could skip the scrappers that are broken right now.