### PR TITLE
handle Null in fields

### DIFF
--- a/vaccine_feed_ingest/runners/ct/state/normalize.py
+++ b/vaccine_feed_ingest/runners/ct/state/normalize.py
@@ -37,11 +37,14 @@ def _get_availability(site: dict) -> Optional[schema.Availability]:
     drop_in, appointments = None, None
 
     for field in ("description", "application_process", "hours_of_operation"):
-        value = site[field].lower()
-        if "appointment" in value:
-            appointments = True
-        if re.search("walk[ |-]in", value):
-            drop_in = True
+        if site[field] == None:
+            site[field] = ''
+        else:
+            value = site[field].lower()
+            if "appointment" in value:
+                appointments = True
+            if re.search("walk[ |-]in", value):
+                drop_in = True
 
     if drop_in or appointments:
         return schema.Availability(drop_in=drop_in, appointments=appointments)

--- a/vaccine_feed_ingest/runners/ct/state/normalize.py
+++ b/vaccine_feed_ingest/runners/ct/state/normalize.py
@@ -37,9 +37,9 @@ def _get_availability(site: dict) -> Optional[schema.Availability]:
     drop_in, appointments = None, None
 
     for field in ("description", "application_process", "hours_of_operation"):
-        if site[field] == None:
+        if site[field] is None:
             continue
-        
+
         value = site[field].lower()
         if "appointment" in value:
             appointments = True

--- a/vaccine_feed_ingest/runners/ct/state/normalize.py
+++ b/vaccine_feed_ingest/runners/ct/state/normalize.py
@@ -37,7 +37,7 @@ def _get_availability(site: dict) -> Optional[schema.Availability]:
     drop_in, appointments = None, None
 
     for field in ("description", "application_process", "hours_of_operation"):
-        if site[field] is None:
+        if not site.get(field):
             continue
 
         value = site[field].lower()

--- a/vaccine_feed_ingest/runners/ct/state/normalize.py
+++ b/vaccine_feed_ingest/runners/ct/state/normalize.py
@@ -38,13 +38,13 @@ def _get_availability(site: dict) -> Optional[schema.Availability]:
 
     for field in ("description", "application_process", "hours_of_operation"):
         if site[field] == None:
-            site[field] = ''
-        else:
-            value = site[field].lower()
-            if "appointment" in value:
-                appointments = True
-            if re.search("walk[ |-]in", value):
-                drop_in = True
+            continue
+        
+        value = site[field].lower()
+        if "appointment" in value:
+            appointments = True
+        if re.search("walk[ |-]in", value):
+            drop_in = True
 
     if drop_in or appointments:
         return schema.Availability(drop_in=drop_in, appointments=appointments)


### PR DESCRIPTION
# <!-- Normalize State for CT (e.g.,  Normalize ArcGIS for MD) -->

| Key Details |
|-|
| Resolves #624  |
State: CT |
Site: state |

## Notes
The field "hours_of_operation" had some Nulls, so added `continue` to skip anytime a field is null

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```
$ poetry run vaccine-feed-ingest all-stages ct/state
2021-05-12T15:28:42-0700 INFO:stages/ingest.py:Fetching ct/state and saving fetched output to /var/folders/yf/ps34_b0x5pn_ddj9skx0gwph0000gn/T/tmptj2tvdd7_fetch_ct_state/output
2021-05-12T15:28:46-0700 INFO:stages/ingest.py:Copying files from /var/folders/yf/ps34_b0x5pn_ddj9skx0gwph0000gn/T/tmptj2tvdd7_fetch_ct_state/output to out/ct/state/raw/2021-05-12T15:28:42
2021-05-12T15:28:46-0700 INFO:stages/ingest.py:Parsing ct/state and saving parsed output to /var/folders/yf/ps34_b0x5pn_ddj9skx0gwph0000gn/T/tmpurx9_unv_parse_ct_state/output
2021-05-12T15:28:46-0700 INFO:stages/ingest.py:Copying files from /var/folders/yf/ps34_b0x5pn_ddj9skx0gwph0000gn/T/tmpurx9_unv_parse_ct_state/output to out/ct/state/parsed/2021-05-12T15:28:42
2021-05-12T15:28:46-0700 INFO:stages/ingest.py:Normalizing ct/state and saving normalized output to /var/folders/yf/ps34_b0x5pn_ddj9skx0gwph0000gn/T/tmp5z9lfd86_normalize_ct_state/output
2021-05-12T15:28:48-0700 INFO:stages/ingest.py:Copying files from /var/folders/yf/ps34_b0x5pn_ddj9skx0gwph0000gn/T/tmp5z9lfd86_normalize_ct_state/output to out/ct/state/normalized/2021-05-12T15:28:42
```

## Before Opening a PR
- [ X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
