### PR TITLE
use location_id_from_name to generate location_id

### DIFF
--- a/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
@@ -25,8 +25,9 @@ def _get_city(site: dict) -> str:
 
 def _get_id(site: dict) -> str:
     name = _get_name(site)
+    city = _get_city(site)
 
-    id = location_id_from_name(name)
+    id = location_id_from_name(f"{name}_{city}")
 
     return id
 

--- a/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from vaccine_feed_ingest_schema import location as schema
 
 from vaccine_feed_ingest.utils.log import getLogger
+from vaccine_feed_ingest.utils.parse import location_id_from_name
 
 logger = getLogger(__file__)
 
@@ -24,12 +25,8 @@ def _get_city(site: dict) -> str:
 
 def _get_id(site: dict) -> str:
     name = _get_name(site)
-    city = _get_city(site)
 
-    id = f"{name}_{city}".lower()
-    id = id.replace(" ", "_").replace("\u2019", "_")
-    id = id.replace(".", "_").replace(",", "_").replace("'", "_")
-    id = id.replace("(", "_").replace(")", "_").replace("/", "_")
+    id = location_id_from_name(name)
 
     return id
 


### PR DESCRIPTION
# Normalize maine_gov for ME

| Key Details |
|-|
| Resolves #625  |
State: ME |
Site: maine_gov |

## Notes
normalize.py was creating id's in a way that did not match the regex in schema. Updated to use `location_id_from_name`.

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
