### PR TITLE
remove state requirement for parser and update normalizer for when li…

### DIFF
--- a/vaccine_feed_ingest/runners/tn/vaccinate_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/tn/vaccinate_gov/normalize.py
@@ -12,7 +12,7 @@ import pathlib
 import sys
 from typing import List, Optional
 
-from vaccine_feed_ingest_schema import schema  # noqa: E402
+from vaccine_feed_ingest_schema import location as schema  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -50,7 +50,7 @@ def _get_city(site: dict) -> str:
 
 
 def _get_address(site: dict) -> Optional[schema.Address]:
-    if "address" not in site:
+    if "address" not in site or "lines" not in site:
         return None
 
     return schema.Address(

--- a/vaccine_feed_ingest/runners/tn/vaccinate_gov/parse.py
+++ b/vaccine_feed_ingest/runners/tn/vaccinate_gov/parse.py
@@ -24,8 +24,8 @@ def parse_address(address):
 
     rest = match.group("rest")
     tn_pattern = re.compile(r",?\s*\b(TN|Tennessee)\b", re.IGNORECASE)
-    if re.search(tn_pattern, rest) is None:
-        raise Exception(f"This address doesn't look like it's for Tennessee: {address}")
+    # if re.search(tn_pattern, rest) is None:
+    #     raise Exception(f"This address doesn't look like it's for Tennessee: {address}")
     city = re.sub(tn_pattern, "", rest)
 
     return {


### PR DESCRIPTION
…nes are not present

# Parse/Normalize vaccinate_gov for TN

| Key Details |
|-|
| Resolves #622  |
State: TN |
Site: vaccinate_gov |

## Notes
The parser failed if it couldn't find TN or Tennessee in an address. Removed this requirement. This caused the normalizer to fail in cases where there was an "address" but no "lines", so updated the normalizer.

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
