### PR TITLE
Add caching framework for caching api calls during enrichment 

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -574,7 +574,7 @@ python-versions = "*"
 
 [[package]]
 name = "ipykernel"
-version = "5.5.4"
+version = "5.5.5"
 description = "IPython Kernel for Jupyter"
 category = "main"
 optional = false
@@ -2085,7 +2085,7 @@ test = ["pytest", "pytest-runner"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "8d8552161e4458b24b4576e1d3345bcf1c8507e55a5f08061411a8472e2d4983"
+content-hash = "66e80974c3ca89df49cc1461301082e884963684a391499af3fe845a655114b4"
 
 [metadata.files]
 aiohttp = [
@@ -2396,8 +2396,8 @@ iniconfig = [
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 ipykernel = [
-    {file = "ipykernel-5.5.4-py3-none-any.whl", hash = "sha256:f57739bf26d7396549562c0c888b96be896385ce099fb34ca89af359b7436b25"},
-    {file = "ipykernel-5.5.4.tar.gz", hash = "sha256:1ce0e83672cc3bfdc1ffb5603e1d77ab125f24b41abc4612e22bfb3e994c0db2"},
+    {file = "ipykernel-5.5.5-py3-none-any.whl", hash = "sha256:29eee66548ee7c2edb7941de60c0ccf0a7a8dd957341db0a49c5e8e6a0fcb712"},
+    {file = "ipykernel-5.5.5.tar.gz", hash = "sha256:e976751336b51082a89fc2099fb7f96ef20f535837c398df6eab1283c2070884"},
 ]
 ipython = [
     {file = "ipython-7.23.1-py3-none-any.whl", hash = "sha256:f78c6a3972dde1cc9e4041cbf4de583546314ba52d3c97208e5b6b2221a9cb7d"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -321,6 +321,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "diskcache"
+version = "5.2.1"
+description = "Disk Cache -- Disk and file backed persistent cache."
+category = "main"
+optional = false
+python-versions = ">=3"
+
+[[package]]
 name = "distlib"
 version = "0.3.1"
 description = "Distribution utilities"
@@ -2280,6 +2288,10 @@ defusedxml = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
+diskcache = [
+    {file = "diskcache-5.2.1-py3-none-any.whl", hash = "sha256:6e8137c778fd2752b93c8a8f944e939b3665d645b46774d8537dd3528ac3baa1"},
+    {file = "diskcache-5.2.1.tar.gz", hash = "sha256:1805acd5868ac10ad547208951a1190a0ab7bbff4e70f9a07cde4dbdfaa69f64"},
+]
 distlib = [
     {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},
     {file = "distlib-0.3.1.zip", hash = "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"},
@@ -2505,40 +2517,30 @@ lxml = [
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4bff24dfeea62f2e56f5bab929b4428ae6caba2d1eea0c2d6eb618e30a71e6d4"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"},
-    {file = "lxml-4.6.3-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:4c61b3a0db43a1607d6264166b230438f85bfed02e8cff20c22e564d0faff354"},
-    {file = "lxml-4.6.3-cp35-cp35m-manylinux2014_x86_64.whl", hash = "sha256:5c8c163396cc0df3fd151b927e74f6e4acd67160d6c33304e805b84293351d16"},
     {file = "lxml-4.6.3-cp35-cp35m-win32.whl", hash = "sha256:f2380a6376dfa090227b663f9678150ef27543483055cc327555fb592c5967e2"},
     {file = "lxml-4.6.3-cp35-cp35m-win_amd64.whl", hash = "sha256:c4f05c5a7c49d2fb70223d0d5bcfbe474cf928310ac9fa6a7c6dddc831d0b1d4"},
     {file = "lxml-4.6.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d2e35d7bf1c1ac8c538f88d26b396e73dd81440d59c1ef8522e1ea77b345ede4"},
     {file = "lxml-4.6.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:289e9ca1a9287f08daaf796d96e06cb2bc2958891d7911ac7cae1c5f9e1e0ee3"},
     {file = "lxml-4.6.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:bccbfc27563652de7dc9bdc595cb25e90b59c5f8e23e806ed0fd623755b6565d"},
-    {file = "lxml-4.6.3-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d916d31fd85b2f78c76400d625076d9124de3e4bda8b016d25a050cc7d603f24"},
     {file = "lxml-4.6.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:820628b7b3135403540202e60551e741f9b6d3304371712521be939470b454ec"},
-    {file = "lxml-4.6.3-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:c47ff7e0a36d4efac9fd692cfa33fbd0636674c102e9e8d9b26e1b93a94e7617"},
     {file = "lxml-4.6.3-cp36-cp36m-win32.whl", hash = "sha256:5a0a14e264069c03e46f926be0d8919f4105c1623d620e7ec0e612a2e9bf1c04"},
     {file = "lxml-4.6.3-cp36-cp36m-win_amd64.whl", hash = "sha256:92e821e43ad382332eade6812e298dc9701c75fe289f2a2d39c7960b43d1e92a"},
     {file = "lxml-4.6.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:efd7a09678fd8b53117f6bae4fa3825e0a22b03ef0a932e070c0bdbb3a35e654"},
     {file = "lxml-4.6.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:efac139c3f0bf4f0939f9375af4b02c5ad83a622de52d6dfa8e438e8e01d0eb0"},
     {file = "lxml-4.6.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:0fbcf5565ac01dff87cbfc0ff323515c823081c5777a9fc7703ff58388c258c3"},
-    {file = "lxml-4.6.3-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:36108c73739985979bf302006527cf8a20515ce444ba916281d1c43938b8bb96"},
     {file = "lxml-4.6.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:122fba10466c7bd4178b07dba427aa516286b846b2cbd6f6169141917283aae2"},
-    {file = "lxml-4.6.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:cdaf11d2bd275bf391b5308f86731e5194a21af45fbaaaf1d9e8147b9160ea92"},
     {file = "lxml-4.6.3-cp37-cp37m-win32.whl", hash = "sha256:3439c71103ef0e904ea0a1901611863e51f50b5cd5e8654a151740fde5e1cade"},
     {file = "lxml-4.6.3-cp37-cp37m-win_amd64.whl", hash = "sha256:4289728b5e2000a4ad4ab8da6e1db2e093c63c08bdc0414799ee776a3f78da4b"},
     {file = "lxml-4.6.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b007cbb845b28db4fb8b6a5cdcbf65bacb16a8bd328b53cbc0698688a68e1caa"},
     {file = "lxml-4.6.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:76fa7b1362d19f8fbd3e75fe2fb7c79359b0af8747e6f7141c338f0bee2f871a"},
     {file = "lxml-4.6.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:26e761ab5b07adf5f555ee82fb4bfc35bf93750499c6c7614bd64d12aaa67927"},
-    {file = "lxml-4.6.3-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:e1cbd3f19a61e27e011e02f9600837b921ac661f0c40560eefb366e4e4fb275e"},
     {file = "lxml-4.6.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:66e575c62792c3f9ca47cb8b6fab9e35bab91360c783d1606f758761810c9791"},
-    {file = "lxml-4.6.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:1b38116b6e628118dea5b2186ee6820ab138dbb1e24a13e478490c7db2f326ae"},
     {file = "lxml-4.6.3-cp38-cp38-win32.whl", hash = "sha256:89b8b22a5ff72d89d48d0e62abb14340d9e99fd637d046c27b8b257a01ffbe28"},
     {file = "lxml-4.6.3-cp38-cp38-win_amd64.whl", hash = "sha256:2a9d50e69aac3ebee695424f7dbd7b8c6d6eb7de2a2eb6b0f6c7db6aa41e02b7"},
     {file = "lxml-4.6.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ce256aaa50f6cc9a649c51be3cd4ff142d67295bfc4f490c9134d0f9f6d58ef0"},
     {file = "lxml-4.6.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:7610b8c31688f0b1be0ef882889817939490a36d0ee880ea562a4e1399c447a1"},
     {file = "lxml-4.6.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f8380c03e45cf09f8557bdaa41e1fa7c81f3ae22828e1db470ab2a6c96d8bc23"},
-    {file = "lxml-4.6.3-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:3082c518be8e97324390614dacd041bb1358c882d77108ca1957ba47738d9d59"},
     {file = "lxml-4.6.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:884ab9b29feaca361f7f88d811b1eea9bfca36cf3da27768d28ad45c3ee6f969"},
-    {file = "lxml-4.6.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:6f12e1427285008fd32a6025e38e977d44d6382cf28e7201ed10d6c1698d2a9a"},
     {file = "lxml-4.6.3-cp39-cp39-win32.whl", hash = "sha256:33bb934a044cf32157c12bfcfbb6649807da20aa92c062ef51903415c704704f"},
     {file = "lxml-4.6.3-cp39-cp39-win_amd64.whl", hash = "sha256:542d454665a3e277f76954418124d67516c5f88e51a900365ed54a9806122b83"},
     {file = "lxml-4.6.3.tar.gz", hash = "sha256:39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ phonenumbers = "^8.12.23"
 pyproj = "^3.0.1"
 ndjson = "^0.3.1"
 orjson = "^3.5.2"
+diskcache = "^5.2.1"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.23.1"

--- a/tests/stages/test_caching.py
+++ b/tests/stages/test_caching.py
@@ -1,0 +1,24 @@
+import pathlib
+
+from vaccine_feed_ingest.stages import caching
+
+
+def test_cache_from_archive(tmpdir):
+    tmp_path = pathlib.Path(tmpdir)
+    archive_path = tmp_path / "archive.tar.gz"
+
+    assert not archive_path.exists()
+
+    with caching.cache_from_archive(archive_path) as cache:
+        assert cache is not None
+
+        assert not cache.get("key")
+        cache.set("key", "value")
+        assert cache.get("key") == "value"
+
+    assert archive_path.exists()
+
+    with caching.cache_from_archive(archive_path) as cache:
+        assert cache is not None
+
+        assert cache.get("key")

--- a/tox.ini
+++ b/tox.ini
@@ -40,4 +40,5 @@ commands =
 deps =
   test
 commands=
+  poetry install --quiet --no-root --no-interaction
   poetry run pytest tests {posargs}

--- a/vaccine_feed_ingest/stages/caching.py
+++ b/vaccine_feed_ingest/stages/caching.py
@@ -1,0 +1,50 @@
+"""Load and store a diskcache from remote storage"""
+
+import contextlib
+import tempfile
+import pathlib
+import tarfile
+import shutil
+from typing import Iterator
+
+import diskcache
+
+
+@contextlib.contextmanager
+def cache_from_archive(archive_path: pathlib.Path) -> Iterator[diskcache.Cache]:
+    """Load a diskcache from remote archive, and write it back when done"""
+
+    with tempfile.TemporaryDirectory("_cache") as tmp_str:
+        tmp_dir = pathlib.Path(tmp_str)
+
+        tmp_diskcache_dir = tmp_dir / "diskcache"
+        tmp_diskcache_dir.mkdir()
+
+        # If there is an existing archive file, then extract the diskcache from it.
+        if archive_path.exists():
+            with tarfile.open(archive_path, mode="r|gz") as archive_file:
+                archive_file.extractall(tmp_diskcache_dir)
+
+        with diskcache.Cache(
+            tmp_diskcache_dir, disk=diskcache.JSONDisk, disk_compress_level=1
+        ) as cache:
+            # Before using cache cull expired items
+            cache.cull()
+
+            yield cache
+
+            # After done with cache, cull expired items
+            cache.cull()
+
+        tmp_archive_name = tmp_dir / "diskcache"
+        tmp_archive_str = shutil.make_archive(
+            str(tmp_archive_name), "gztar", tmp_diskcache_dir
+        )
+
+        tmp_archive_path = pathlib.Path(tmp_archive_str)
+
+        # Overwrite cache archive with new data
+        with tmp_archive_path.open("rb") as src_file:
+            with archive_path.open("wb") as dst_file:
+                for content in src_file:
+                    dst_file.write(content)

--- a/vaccine_feed_ingest/stages/caching.py
+++ b/vaccine_feed_ingest/stages/caching.py
@@ -26,7 +26,10 @@ def cache_from_archive(archive_path: pathlib.Path) -> Iterator[diskcache.Cache]:
                 archive_file.extractall(tmp_diskcache_dir)
 
         with diskcache.Cache(
-            tmp_diskcache_dir, disk=diskcache.JSONDisk, disk_compress_level=1
+            tmp_diskcache_dir,
+            disk=diskcache.JSONDisk,
+            disk_compress_level=1,
+            eviction_policy="least-frequently-used",
         ) as cache:
             # Before using cache cull expired items
             cache.cull()
@@ -42,6 +45,8 @@ def cache_from_archive(archive_path: pathlib.Path) -> Iterator[diskcache.Cache]:
         )
 
         tmp_archive_path = pathlib.Path(tmp_archive_str)
+
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Overwrite cache archive with new data
         with tmp_archive_path.open("rb") as src_file:

--- a/vaccine_feed_ingest/stages/caching.py
+++ b/vaccine_feed_ingest/stages/caching.py
@@ -1,10 +1,10 @@
 """Load and store a diskcache from remote storage"""
 
 import contextlib
-import tempfile
 import pathlib
-import tarfile
 import shutil
+import tarfile
+import tempfile
 from typing import Iterator
 
 import diskcache

--- a/vaccine_feed_ingest/stages/enrichment.py
+++ b/vaccine_feed_ingest/stages/enrichment.py
@@ -2,6 +2,7 @@
 import pathlib
 from typing import Dict, Optional
 
+import diskcache
 import phonenumbers
 import pydantic
 from vaccine_feed_ingest_schema import location
@@ -18,7 +19,11 @@ logger = getLogger(__file__)
 PROVIDER_TAG = "_tag_provider"
 
 
-def enrich_locations(input_dir: pathlib.Path, output_dir: pathlib.Path) -> bool:
+def enrich_locations(
+    input_dir: pathlib.Path,
+    output_dir: pathlib.Path,
+    api_cache: Optional[diskcache.Cache] = None,
+) -> bool:
     """Enrich locations in normalized input_dir and write them to output_dir"""
     enriched_locations = []
 

--- a/vaccine_feed_ingest/stages/ingest.py
+++ b/vaccine_feed_ingest/stages/ingest.py
@@ -12,7 +12,7 @@ from vaccine_feed_ingest_schema import location
 from vaccine_feed_ingest.utils.log import getLogger
 
 from ..utils.validation import VACCINATE_THE_STATES_BOUNDARY
-from . import enrichment, outputs, site
+from . import caching, enrichment, outputs, site
 from .common import STAGE_OUTPUT_SUFFIX, PipelineStage
 
 logger = getLogger(__file__)
@@ -343,7 +343,18 @@ def run_enrich(
             enrich_output_dir,
         )
 
-        success = enrichment.enrich_locations(enrich_input_dir, enrich_output_dir)
+        enrich_stage_dir = outputs.generate_stage_dir(
+            output_dir,
+            site_dir.parent.name,
+            site_dir.name,
+            PipelineStage.ENRICH,
+        )
+
+        api_cache_path = enrich_stage_dir / ".api_cache.tar.gz"
+        with caching.cache_from_archive(api_cache_path) as api_cache:
+            success = enrichment.enrich_locations(
+                enrich_input_dir, enrich_output_dir, api_cache
+            )
 
         if not success:
             logger.error(

--- a/vaccine_feed_ingest/stages/outputs.py
+++ b/vaccine_feed_ingest/stages/outputs.py
@@ -13,7 +13,7 @@ def find_all_run_dirs(
     stage: PipelineStage,
 ) -> Iterator[pathlib.Path]:
     """Find latest stage output path"""
-    stage_dir = base_output_dir / state / site / STAGE_OUTPUT_NAME[stage]
+    stage_dir = generate_stage_dir(base_output_dir, state, site, stage)
 
     if not stage_dir.exists():
         return
@@ -38,6 +38,25 @@ def find_latest_run_dir(
     return next(find_all_run_dirs(base_output_dir, state, site, stage), None)
 
 
+def generate_site_dir(
+    base_output_dir: pathlib.Path,
+    state: str,
+    site: str,
+) -> pathlib.Path:
+    """Generate output path for site"""
+    return base_output_dir / state / site
+
+
+def generate_stage_dir(
+    base_output_dir: pathlib.Path,
+    state: str,
+    site: str,
+    stage: PipelineStage,
+) -> pathlib.Path:
+    """Generate output path for pipeline stage."""
+    return generate_site_dir(base_output_dir, state, site) / STAGE_OUTPUT_NAME[stage]
+
+
 def generate_run_dir(
     base_output_dir: pathlib.Path,
     state: str,
@@ -45,8 +64,8 @@ def generate_run_dir(
     stage: PipelineStage,
     timestamp: str,
 ) -> pathlib.Path:
-    """Generate output path for a pipeline stage."""
-    return base_output_dir / state / site / STAGE_OUTPUT_NAME[stage] / timestamp
+    """Generate output path for a specific run of a pipeline stage."""
+    return generate_stage_dir(base_output_dir, state, site, stage) / timestamp
 
 
 def iter_data_paths(


### PR DESCRIPTION
Creates the concept of a cache which stores items as JSON entries in a sqllite3 DB using [diskcache](http://www.grantjenks.com/docs/diskcache).

A "api_cache" is then passed to enrichment stage and this cache can be used to cache api calls so we don't call the api everytime. Each site has its own "api_cache" so feeds can still be processed independently.

The cache is stored in GCS as a gzipped tar at each site's enrich root  (e.g. `us/vaccinespotter_org/enrich/.api_cache.tar.gz`), and is loaded at the beginning of enriching a site feed, and then stored when finished.

The usage of this cache will be defined in a future PR, but the idea is to use this like a memoize cache for api calls with a cache expire of maybe `45 +/- 15` days, so we can refresh things eventually, but not overwhelm servers