### PR TITLE
fix: stable ids for il/sf_sites

### DIFF
--- a/vaccine_feed_ingest/runners/il/sfsites/normalize.py
+++ b/vaccine_feed_ingest/runners/il/sfsites/normalize.py
@@ -5,7 +5,7 @@ import json
 import pathlib
 import re
 import sys
-from typing import List, Optional
+from typing import List, Optional, Set
 
 import pydantic
 from vaccine_feed_ingest_schema import location as schema
@@ -17,6 +17,26 @@ logger = getLogger(__file__)
 URL_RE = re.compile(
     r"(https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})"
 )
+
+
+def _id(loc: schema.LatLng, name: str, addr: schema.Address) -> str:
+    # The ids provided in this site's data are not stable, so we need to
+    # construct our own stable id.
+    #
+    # Here we use the lat/lng to a precision of 4 decimal places, the name, and
+    # the first line of the address (without the first line of the address,
+    # there are several id collisions for separate locations - perhaps where
+    # the data source has the improper lat/lng for one).
+    #
+    # This technique means the id will be unstable when these fields are changed
+    # in the data source, but that's a better outcome than being unstable on
+    # each run. Additionally, we truncate the name and address to attempt to be
+    # a bit more stable.
+    return re.sub(
+        "[^a-zA-Z0-9-_]",
+        "_",
+        f"{loc.latitude:.4f}_{loc.longitude:.4f}_{name[:16].upper()}_{addr.street1[:16].upper()}",
+    )
 
 
 def _get_address(site: dict) -> schema.Address:
@@ -81,11 +101,18 @@ def _get_parent_organization(name: str) -> Optional[schema.Organization]:
     return None
 
 
-def normalize(site: dict, timestamp: str) -> dict:
+def normalize(site: dict, timestamp: str) -> schema.NormalizedLocation:
     source_id = "il_sfsites"
-    location_id = site["Id"]
     name = site["Testing_Center__c"]
     notes = []
+
+    loc = schema.LatLng(
+        latitude=site["Geolocation__Latitude__s"],
+        longitude=site["Geolocation__Longitude__s"],
+    )
+    addr = _get_address(site)
+
+    location_id = _id(loc, name, addr)
 
     if "Location_Type__c" in site:
         notes.append(site["Location_Type__c"])
@@ -93,11 +120,8 @@ def normalize(site: dict, timestamp: str) -> dict:
     return schema.NormalizedLocation(
         id=f"{source_id}:{location_id}",
         name=name,
-        address=_get_address(site),
-        location=schema.LatLng(
-            latitude=site["Geolocation__Latitude__s"],
-            longitude=site["Geolocation__Longitude__s"],
-        ),
+        address=addr,
+        location=loc,
         contact=_get_contact(site),
         languages=None,
         opening_dates=None,
@@ -129,12 +153,33 @@ parsed_at_timestamp = datetime.datetime.utcnow().isoformat()
 
 out_filepath = output_dir / "locations.normalized.ndjson"
 
+ids_seen: Set[str] = set()
+
 with input_filepath.open() as fin:
     with out_filepath.open("w") as fout:
         for site_json in fin:
             parsed_site = json.loads(site_json)
 
             normalized_site = normalize(parsed_site, parsed_at_timestamp)
+
+            # This data source contains some duplicates with slightly different
+            # formatting (e.g., the address is ALL CAPS on one copy). In the
+            # case where this duplication causes us to repeat an id, drop all
+            # records other than the first occurrence. Note that some of the
+            # modifications we make in order to make ids more stable also
+            # increase the risk of id re-use with this type of duplicate.
+            #
+            # This still passes through several duplicates where the formatting
+            # is meaningfully different (e.g., North vs. N.).
+            if normalized_site.id in ids_seen:
+                logger.warning(
+                    "id %s is being reused. Dropping the reused location: %s",
+                    normalized_site.id,
+                    normalized_site,
+                )
+                continue
+
+            ids_seen.add(normalized_site.id)
 
             json.dump(normalized_site.dict(), fout)
             fout.write("\n")


### PR DESCRIPTION
Presently the ids for `il/sf_sites` change on each run of the pipeline, so we disabled the site. Manually create a stable id instead.