### PR TITLE
Commands for managing api cache

### DIFF
--- a/vaccine_feed_ingest/stages/caching.py
+++ b/vaccine_feed_ingest/stages/caching.py
@@ -9,6 +9,26 @@ from typing import Iterator
 
 import diskcache
 
+from . import common, outputs
+
+
+@contextlib.contextmanager
+def api_cache_for_stage(
+    base_output_dir: pathlib.Path,
+    site_dir: pathlib.Path,
+    stage: common.PipelineStage,
+) -> Iterator[diskcache.Cache]:
+    """Load api cache from archive for the specified site and stage"""
+    api_cache_path = outputs.generate_api_cache_path(
+        base_output_dir,
+        site_dir.parent.name,
+        site_dir.name,
+        stage,
+    )
+
+    with cache_from_archive(api_cache_path) as api_cache:
+        yield api_cache
+
 
 @contextlib.contextmanager
 def cache_from_archive(archive_path: pathlib.Path) -> Iterator[diskcache.Cache]:

--- a/vaccine_feed_ingest/stages/caching.py
+++ b/vaccine_feed_ingest/stages/caching.py
@@ -30,6 +30,41 @@ def api_cache_for_stage(
         yield api_cache
 
 
+def remove_api_cache(
+    base_output_dir: pathlib.Path,
+    site_dir: pathlib.Path,
+    stage: common.PipelineStage,
+) -> None:
+    api_cache_path = outputs.generate_api_cache_path(
+        base_output_dir,
+        site_dir.parent.name,
+        site_dir.name,
+        stage,
+    )
+
+    api_cache_path.unlink(missing_ok=True)
+
+
+def evict_api_cache(
+    base_output_dir: pathlib.Path,
+    site_dir: pathlib.Path,
+    stage: common.PipelineStage,
+    tag: str,
+) -> int:
+    api_cache_path = outputs.generate_api_cache_path(
+        base_output_dir,
+        site_dir.parent.name,
+        site_dir.name,
+        stage,
+    )
+
+    if not api_cache_path.exists():
+        return 0
+
+    with api_cache_for_stage(base_output_dir, site_dir, stage) as api_cache:
+        return api_cache.evict(tag)
+
+
 @contextlib.contextmanager
 def cache_from_archive(archive_path: pathlib.Path) -> Iterator[diskcache.Cache]:
     """Load a diskcache from remote archive, and write it back when done"""

--- a/vaccine_feed_ingest/stages/ingest.py
+++ b/vaccine_feed_ingest/stages/ingest.py
@@ -343,15 +343,9 @@ def run_enrich(
             enrich_output_dir,
         )
 
-        enrich_stage_dir = outputs.generate_stage_dir(
-            output_dir,
-            site_dir.parent.name,
-            site_dir.name,
-            PipelineStage.ENRICH,
-        )
-
-        api_cache_path = enrich_stage_dir / ".api_cache.tar.gz"
-        with caching.cache_from_archive(api_cache_path) as api_cache:
+        with caching.api_cache_for_stage(
+            output_dir, site_dir, PipelineStage.ENRICH
+        ) as api_cache:
             success = enrichment.enrich_locations(
                 enrich_input_dir, enrich_output_dir, api_cache
             )

--- a/vaccine_feed_ingest/stages/outputs.py
+++ b/vaccine_feed_ingest/stages/outputs.py
@@ -5,6 +5,8 @@ from typing import Iterator, Optional
 
 from .common import STAGE_OUTPUT_NAME, PipelineStage
 
+API_CACHE_NAME = ".api_cache.tar.gz"
+
 
 def find_all_run_dirs(
     base_output_dir: pathlib.Path,
@@ -66,6 +68,16 @@ def generate_run_dir(
 ) -> pathlib.Path:
     """Generate output path for a specific run of a pipeline stage."""
     return generate_stage_dir(base_output_dir, state, site, stage) / timestamp
+
+
+def generate_api_cache_path(
+    base_output_dir: pathlib.Path,
+    state: str,
+    site: str,
+    stage: PipelineStage,
+) -> pathlib.Path:
+    """Generate api cache path for site and stage."""
+    return generate_stage_dir(base_output_dir, state, site, stage) / API_CACHE_NAME
 
 
 def iter_data_paths(


### PR DESCRIPTION
Added a command to remove an api cache completely, and evict keys with certain tags.

### Remove
```
vaccine-feed-ingest api-cache-remove ca/sf_gov
```

### Evict
```
vaccine-feed-ingest api-cache-evict ca/sf_gov --cache-tag=placekey
```