### PR TITLE
Normalize WA State. Fixes #519

### DIFF
--- a/vaccine_feed_ingest/runners/wa/state/normalize.py
+++ b/vaccine_feed_ingest/runners/wa/state/normalize.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+import datetime
+import json
+import pathlib
+import sys
+from typing import List
+
+from pydantic import ValidationError
+from vaccine_feed_ingest_schema import location as schema
+
+from vaccine_feed_ingest.utils.log import getLogger
+
+logger = getLogger(__file__)
+
+
+def _get_id(site: dict) -> str:
+    # The graphql docs say this id should be unique to this location within
+    # this data source
+    locationId = site["locationId"]
+
+    return locationId
+
+
+def _get_contacts(site: dict) -> List[schema.Contact]:
+    # From the docs for this data source:
+    # These are nullable fields, but one is "guaranteed" to be non nullable
+    phone, email, scheduling_link = (
+        site.get("phone"),
+        site.get("email"),
+        site.get("schedulingLink"),
+    )
+
+    info_link = site.get("infoLink")
+    try:
+        phone_contact = (
+            schema.Contact(
+                contact_type="booking",
+                phone=phone,
+            )
+            if phone is not None
+            else None
+        )
+    except ValidationError:
+        logger.warning(f"Invalid phone contact {phone}")
+        phone_contact = None
+
+    try:
+        email_contact = (
+            schema.Contact(
+                contact_type="booking",
+                email=email,
+            )
+            if email is not None
+            else None
+        )
+    except ValidationError:
+        logger.warning(f"Invalid email contact {email}")
+        email_contact = None
+
+    try:
+        website_contact = (
+            schema.Contact(
+                contact_type="booking",
+                website=scheduling_link,
+            )
+            if scheduling_link is not None
+            else None
+        )
+    except ValidationError:
+        logger.warning(f"Invalid scheduling_link contact {scheduling_link}")
+        website_contact = None
+
+    try:
+        general_contact = (
+            schema.Contact(contact_type="general", website=info_link)
+            if info_link
+            else None
+        )
+    except ValidationError:
+        logger.warning(f"Invalid info_link contact {info_link}")
+        general_contact = None
+
+    return [
+        contact
+        for contact in (phone_contact, email_contact, website_contact, general_contact)
+        if contact is not None
+    ]
+
+
+def _get_wheelchair(site):
+    if site.get("wheelchairAccessible") is True:
+        return "yes"
+    if site.get("wheelchairAccessible") is False:
+        return "no"
+
+    return None
+
+
+def _get_supply_level(site):
+    if site["vaccineAvailability"] == "AVAILABLE":
+        return "in_stock"
+
+    if site["vaccineAvailability"] == "UNAVAILABLE":
+        return "out_of_stock"
+
+    # Docs say the value should be UNKNOWN
+    return None
+
+
+def _get_vaccine_type(type_string):
+    if type_string == "johnsonAndJohnson":
+        return "johnson_johnson_janssen"
+    if type_string == "moderna":
+        return "moderna"
+    if type_string == "pfizer":
+        return "pfizer_biontech"
+    return None
+
+
+def _is_good_zip(zip):
+    if len(zip) != 5:
+        logger.warning(f"Bad zip {zip}")
+        return False
+
+    return True
+
+
+def normalize(site: dict, timestamp: str) -> schema.NormalizedLocation:
+    source_name = "wa_state"
+
+    # NOTE: we use `get` where the field is optional in our data source, and
+    # ["key'] access where it is not.
+    return schema.NormalizedLocation(
+        id=f"{source_name}:{_get_id(site)}",
+        name=site["locationName"],
+        address=schema.Address(
+            street1=site.get("addressLine1"),
+            street2=site.get("addressLine2"),
+            city=site.get("city"),
+            state="WA",
+            zip=site["zipcode"] if _is_good_zip(site["zipcode"]) else None,
+        ),
+        location=schema.LatLng(latitude=site["latitude"], longitude=site["longitude"]),
+        contact=_get_contacts(site),
+        notes=site.get("description"),
+        # Since this could be nullable we make sure to only provide it if it's True or False
+        availability=schema.Availability(drop_in=site.get("walkIn"))
+        if site.get("walkIn") is not None
+        else None,
+        access=schema.Access(
+            walk=site.get("walkupSite"),
+            drive=site.get("driveupSite"),
+            wheelchair=_get_wheelchair(site),
+        ),
+        # IF supply_level is UNKNOWN, don't say anything about it
+        inventory=[
+            schema.Vaccine(
+                vaccine=_get_vaccine_type(vaccine), supply_level=_get_supply_level(site)
+            )
+            for vaccine in site["vaccineTypes"]
+            if _get_vaccine_type(vaccine) is not None
+        ]
+        if _get_supply_level(site)
+        else None,
+        parent_organization=schema.Organization(
+            id=site.get("providerId"), name=site.get("providerName")
+        ),
+        source=schema.Source(
+            source=source_name,
+            id=site["locationId"],
+            fetched_from_uri="https://floridahealthcovid19.gov/vaccines/vaccine-locator/",
+            fetched_at=timestamp,
+            published_at=site["updatedAt"],
+            data=site,
+        ),
+    )
+
+
+parsed_at_timestamp = datetime.datetime.utcnow().isoformat()
+
+input_dir = pathlib.Path(sys.argv[2])
+input_file = input_dir / "data.parsed.ndjson"
+output_dir = pathlib.Path(sys.argv[1])
+output_file = output_dir / "data.normalized.ndjson"
+
+with input_file.open() as parsed_lines:
+    with output_file.open("w") as fout:
+        for line in parsed_lines:
+            site_blob = json.loads(line)
+
+            normalized_site = normalize(site_blob, parsed_at_timestamp)
+
+            json.dump(normalized_site.dict(), fout)
+            fout.write("\n")


### PR DESCRIPTION

| Key Details |
|-|
| Resolves #519 |
State: WA|
Site: state |

## Notes
Not as thorough as I could have been, I ignored bad data instead of fixing it case by case.

I traced from a few other PRs, and I relied on the docs of the graphQL api: https://apim-vaccs-prod.azure-api.net/web/graphql

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```json
{"locationId": "recT5VYLb0qwyVTSz", "locationName": "North Basin - Davenport", "locationType": null, "providerId": null, "providerName": null, "departmentId": null, "departmentName": null, "addressLine1": "100 3rd Street", "addressLine2": null, "city": "Davenport", "state": "Washington", "county": "Lincoln", "zipcode": "99122", "latitude": 47.65713, "longitude": -118.14546, "description": null, "contactFirstName": null, "contactLastName": null, "fax": null, "phone": "(509) 725-7501", "email": null, "schedulingLink": "https://www.lincolnhospital.org/health-resources/covid-19-update/", "vaccineAvailability": "AVAILABLE", "infoLink": null, "timeZoneId": null, "directions": "We are currently scheduling weekly vaccine clinics based on the number of vaccines we receive and individual eligibility. The clinics are by appointment only.\n\nPlease call 509.725.7501 and ask to be added to our wait-list. Please note that the vaccine is still available in limited quantities and our demand is higher than our current supply. We will do the best we can to get your scheduled as quickly as possible.", "updatedAt": "2021-05-08T21:15:02.673Z", "rawDataSourceName": "CovidWaFn", "vaccineTypes": [], "accessibleParking": null, "additionalSupports": null, "commCardAvailable": null, "commCardBrailleAvailable": null, "driveupSite": null, "interpretersAvailable": null, "interpretersDesc": null, "supportUrl": null, "waitingArea": null, "walkupSite": null, "wheelchairAccessible": null, "scheduleOnline": null, "scheduleByPhone": null, "scheduleByEmail": null, "walkIn": null, "waitList": null}
{"locationId": "recmLmhezm8iIK6t0", "locationName": "Valley View Health Center - Winlock", "locationType": null, "providerId": null, "providerName": null, "departmentId": null, "departmentName": null, "addressLine1": "100 Cedar Crest Drive", "addressLine2": null, "city": "Winlock", "state": "Washington", "county": "Lewis", "zipcode": "98596", "latitude": 46.49009, "longitude": -122.92417, "description": null, "contactFirstName": null, "contactLastName": null, "fax": null, "phone": "(360) 330-9595", "email": "Covidphase@vvhc.org ", "schedulingLink": "https://vvhc.org/", "vaccineAvailability": "AVAILABLE", "infoLink": null, "timeZoneId": null, "directions": "Waitlist on website", "updatedAt": "2021-05-08T21:15:02.673Z", "rawDataSourceName": "CovidWaFn", "vaccineTypes": [], "accessibleParking": null, "additionalSupports": null, "commCardAvailable": null, "commCardBrailleAvailable": null, "driveupSite": null, "interpretersAvailable": null, "interpretersDesc": null, "supportUrl": null, "waitingArea": null, "walkupSite": null, "wheelchairAccessible": null, "scheduleOnline": null, "scheduleByPhone": null, "scheduleByEmail": null, "walkIn": null, "waitList": null}
{"locationId": "recfTm7i08Rlz2ao6", "locationName": "Bartell Drugs - Greenwood (Moderna)", "locationType": null, "providerId": null, "providerName": null, "departmentId": null, "departmentName": null, "addressLine1": "100 North 85th Street", "addressLine2": null, "city": "Seattle", "state": "Washington", "county": "King", "zipcode": "98103", "latitude": 47.69113, "longitude": -122.35751, "description": null, "contactFirstName": null, "contactLastName": null, "fax": null, "phone": "(206) 784-7601", "email": null, "schedulingLink": "https://www.bartelldrugs.com/covid-19-vaccine/", "vaccineAvailability": "AVAILABLE", "infoLink": null, "timeZoneId": null, "directions": null, "updatedAt": "2021-05-08T21:11:59.000Z", "rawDataSourceName": "CovidWaFn", "vaccineTypes": [], "accessibleParking": null, "additionalSupports": null, "commCardAvailable": null, "commCardBrailleAvailable": null, "driveupSite": null, "interpretersAvailable": null, "interpretersDesc": null, "supportUrl": null, "waitingArea": null, "walkupSite": null, "wheelchairAccessible": null, "scheduleOnline": null, "scheduleByPhone": null, "scheduleByEmail": null, "walkIn": null, "waitList": null}
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
