### PR TITLE
Open api-cache archive using Pathy so it works with GCS

### DIFF
--- a/vaccine_feed_ingest/stages/caching.py
+++ b/vaccine_feed_ingest/stages/caching.py
@@ -77,8 +77,9 @@ def cache_from_archive(archive_path: pathlib.Path) -> Iterator[diskcache.Cache]:
 
         # If there is an existing archive file, then extract the diskcache from it.
         if archive_path.exists():
-            with tarfile.open(archive_path, mode="r|gz") as archive_file:
-                archive_file.extractall(tmp_diskcache_dir)
+            with archive_path.open(mode="rb") as archive_file:
+                with tarfile.open(fileobj=archive_file, mode="r|gz") as tar_archive:
+                    tar_archive.extractall(tmp_diskcache_dir)
 
         with diskcache.Cache(
             tmp_diskcache_dir,


### PR DESCRIPTION
[Pathy](https://github.com/justindujardin/pathy) uses `smart-open` to access both local and remote files via the `pathlib.Path` interface.

I was using `tarfile` to open the file which worked for local files, but not for remote files. I fixed this by switching to using Pathy to open the file before passing to tarfile, so this now uses the smart open remote/local magic.

I confirmed this worked by running it with :
```
poetry run vaccine-feed-ingest enrich ca/sf_gov --output-dir=gs://vaccine-feeds-dev/locations/
```