### PR TITLE
fix: vial `id` at root, not in properties

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,8 +95,8 @@ def full_location():
 def vial_location():
     return {
         "type": "Feature",
+        "id": "recmq8dNXlV1yWipP",
         "properties": {
-            "id": "recmq8dNXlV1yWipP",
             "name": "RITE AID PHARMACY 05952",
             "state": "CA",
             "latitude": 37.82733,

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -361,13 +361,13 @@ def _match_source_to_existing_locations(
             "MATCH: %s (%s) matched to %s (%s)",
             source.id,
             source.name,
-            match_candidate["properties"]["id"],
+            match_candidate["id"],
             match_candidate["properties"]["name"],
         )
         if enable_match:
             return load.ImportMatchAction(
                 action="existing",
-                id=match_candidate["properties"]["id"],
+                id=match_candidate["id"],
             )
         else:
             return None
@@ -378,9 +378,9 @@ def _match_source_to_existing_locations(
             source.id,
             source.name,
             len(candidates),
-            candidates[0]["properties"]["id"],
+            candidates[0]["id"],
             candidates[0]["properties"]["name"],
-            candidates[1]["properties"]["id"],
+            candidates[1]["id"],
             candidates[1]["properties"]["name"],
         )
     else:

--- a/vaccine_feed_ingest/utils/match.py
+++ b/vaccine_feed_ingest/utils/match.py
@@ -258,7 +258,7 @@ def is_phone_number_similar(
     except phonenumbers.NumberParseException:
         logger.warning(
             "Invalid candidate phone number for location %s: %s",
-            candidate_props["id"],
+            candidate.get("id", "No ID provided"),
             candidate_props["phone_number"],
         )
         return None

--- a/vaccine_feed_ingest/vial.py
+++ b/vaccine_feed_ingest/vial.py
@@ -73,6 +73,10 @@ def import_source_locations(
     import_batch_size: int = 500,
 ) -> None:
     """Import source locations"""
+    path_and_query = f"/api/importSourceLocations?import_run_id={import_run_id}"
+    logger.info("Contacting VIAL: POST %s", path_and_query)
+
+    batches = 0
     for import_locations_batch in misc.batch(import_locations, import_batch_size):
         encoded_ndjson = "\n".join(
             [loc.json(exclude_none=True) for loc in import_locations_batch]
@@ -80,7 +84,7 @@ def import_source_locations(
 
         rsp = vial_http.request(
             "POST",
-            f"/api/importSourceLocations?import_run_id={import_run_id}",
+            path_and_query,
             headers={**vial_http.headers, "Content-Type": "application/x-ndjson"},
             body=encoded_ndjson.encode("utf-8"),
         )
@@ -93,6 +97,16 @@ def import_source_locations(
                 dict(rsp.headers),
                 None,
             )
+
+        batches += 1
+        if batches % 5 == 0:
+            logger.info(
+                "Submitted %d batches of up to %d records to VIAL.",
+                batches,
+                import_batch_size,
+            )
+
+    logger.info("Submitted %d total batches to VIAL.", batches)
 
 
 def search_locations(
@@ -177,16 +191,23 @@ def search_source_locations(
 
     query = urllib.parse.urlencode(params)
 
-    resp = vial_http.request(
-        "GET", f"/api/searchSourceLocations?{query}", preload_content=False
-    )
+    path_and_query = f"/api/searchSourceLocations?{query}"
+    logger.info("Contacting VIAL: GET %s", path_and_query)
 
+    resp = vial_http.request("GET", path_and_query, preload_content=False)
+
+    lines = 0
     for line in resp:
         try:
             yield geojson.loads(line)
         except json.JSONDecodeError:
             logger.warning("Invalid json record in search response: %s", line)
 
+        lines += 1
+        if lines % 5000 == 0:
+            logger.info("Processed %d records from VIAL.", lines)
+
+    logger.info("Processed %d total records from VIAL.", lines)
     resp.release_conn()
 
 

--- a/vaccine_feed_ingest/vial.py
+++ b/vaccine_feed_ingest/vial.py
@@ -137,7 +137,7 @@ def retrieve_existing_locations(
 
 def _generate_index_row(loc: dict) -> Tuple[int, tuple, dict]:
     """Generate a rtree index entry from geojson entry"""
-    loc_id = hash(loc["properties"]["id"])
+    loc_id = hash(loc["id"])
     loc_shape = shapely.geometry.shape(loc["geometry"])
     loc_bounds = loc_shape.bounds
 

--- a/vaccine_feed_ingest/vial.py
+++ b/vaccine_feed_ingest/vial.py
@@ -107,15 +107,23 @@ def search_locations(
 
     query = urllib.parse.urlencode(params)
 
-    resp = vial_http.request(
-        "GET", f"/api/searchLocations?{query}", preload_content=False
-    )
+    path_and_query = f"/api/searchLocations?{query}"
+    logger.info("Contacting VIAL: GET %s", path_and_query)
 
+    resp = vial_http.request("GET", path_and_query, preload_content=False)
+
+    lines = 0
     for line in resp:
         try:
             yield geojson.loads(line)
         except json.JSONDecodeError:
             logger.warning("Invalid json record in search response: %s", line)
+
+        lines += 1
+        if lines % 5000 == 0:
+            logger.info("Processed %d records from VIAL.", lines)
+
+    logger.info("Processed %d total records from VIAL.", lines)
 
     resp.release_conn()
 


### PR DESCRIPTION
On 2021-05-14, `VIAL` updated its `nlgeojson` response format per feedback from a partner.

Among other updates, the `id` field which was previously available both at `.id` and `.properties.id` was consolidated to `.id` only.

Update matching logic to use the consolidated field.

NOTE: it is possible that other schema changes may be breaking to some logic herein. I did not attempt to re-validate existing matching rules against the schema changes, only to fix the issue blocking streaming locations from VIAL.