### PR TITLE
Skip importing locations that haven't changed since last load

### DIFF
--- a/tests/utils/test_normalize.py
+++ b/tests/utils/test_normalize.py
@@ -1,0 +1,25 @@
+from vaccine_feed_ingest.utils import normalize
+
+
+def test_calculate_content_hash(full_location):
+    original_hash = normalize.calculate_content_hash(full_location)
+    assert original_hash
+
+    original_hash_again = normalize.calculate_content_hash(full_location)
+    assert original_hash_again
+
+    assert original_hash_again == original_hash
+
+    full_location.source.fetched_at = "1980-01-01T01:01:01"
+
+    source_modified_hash = normalize.calculate_content_hash(full_location)
+    assert source_modified_hash
+
+    assert source_modified_hash == original_hash
+
+    full_location.name = "New Location Name"
+
+    name_modified_hash = normalize.calculate_content_hash(full_location)
+    assert name_modified_hash
+
+    assert name_modified_hash != original_hash

--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -166,6 +166,15 @@ def _rematch_option() -> Callable:
     )
 
 
+def _reimport_option() -> Callable:
+    return click.option(
+        "--reimport/--no-reimport",
+        "enable_reimport",
+        type=bool,
+        default=lambda: os.environ.get("ENABLE_REIMPORT", "false").lower() == "true",
+    )
+
+
 def _match_ids_option() -> Callable:
     return click.option(
         "--match-ids",
@@ -436,6 +445,7 @@ def enrich(
 @_match_option()
 @_create_option()
 @_rematch_option()
+@_reimport_option()
 @_match_ids_option()
 @_create_ids_option()
 @_candidate_distance_option()
@@ -451,6 +461,7 @@ def load_to_vial(
     enable_match: bool,
     enable_create: bool,
     enable_rematch: bool,
+    enable_reimport: bool,
     match_ids: Optional[Dict[str, str]],
     create_ids: Optional[Collection[str]],
     candidate_distance: float,
@@ -475,6 +486,7 @@ def load_to_vial(
         enable_match=enable_match,
         enable_create=enable_create,
         enable_rematch=enable_rematch,
+        enable_reimport=enable_reimport,
         match_ids=match_ids,
         create_ids=create_ids,
         candidate_distance=candidate_distance,
@@ -497,6 +509,7 @@ def load_to_vial(
 @_match_option()
 @_create_option()
 @_rematch_option()
+@_reimport_option()
 @_match_ids_option()
 @_create_ids_option()
 @_candidate_distance_option()
@@ -517,6 +530,7 @@ def pipeline(
     enable_match: bool,
     enable_create: bool,
     enable_rematch: bool,
+    enable_reimport: bool,
     match_ids: Optional[Dict[str, str]],
     create_ids: Optional[Collection[str]],
     candidate_distance: float,
@@ -594,6 +608,7 @@ def pipeline(
             enable_match=enable_match,
             enable_create=enable_create,
             enable_rematch=enable_rematch,
+            enable_reimport=enable_reimport,
             match_ids=match_ids,
             create_ids=create_ids,
             candidate_distance=candidate_distance,

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -13,6 +13,7 @@ from vaccine_feed_ingest_schema import load, location
 from vaccine_feed_ingest.utils.log import getLogger
 
 from .. import vial
+from ..utils import normalize
 from ..utils.match import (
     is_address_similar,
     is_concordance_similar,
@@ -45,7 +46,7 @@ def load_sites_to_vial(
         import_run_id = vial.start_import_run(vial_http)
 
         locations = None
-        matched_ids = None
+        source_locations = None
 
         if enable_match or enable_create:
             logger.info("Loading existing location from VIAL")
@@ -54,7 +55,7 @@ def load_sites_to_vial(
             # Skip loading already matched if re-matching
             if not enable_rematch:
                 logger.info("Loading already matched source locations from VIAL")
-                matched_ids = vial.retrieve_matched_source_location_ids(vial_http)
+                source_locations = vial.retrieve_source_location_hashes(vial_http)
 
         for site_dir in site_dirs:
             imported_locations = run_load_to_vial(
@@ -64,7 +65,7 @@ def load_sites_to_vial(
                 vial_http=vial_http,
                 import_run_id=import_run_id,
                 locations=locations,
-                matched_ids=matched_ids,
+                source_locations=source_locations,
                 enable_match=enable_match,
                 enable_create=enable_create,
                 enable_rematch=enable_rematch,
@@ -94,7 +95,7 @@ def run_load_to_vial(
     vial_http: urllib3.connectionpool.ConnectionPool,
     import_run_id: str,
     locations: Optional[rtree.index.Index],
-    matched_ids: Optional[Collection[str]],
+    source_locations: Optional[Dict[str, vial.SourceLocationHash]],
     enable_match: bool = True,
     enable_create: bool = False,
     enable_rematch: bool = False,
@@ -124,6 +125,7 @@ def run_load_to_vial(
     num_new_locations = 0
     num_match_locations = 0
     num_already_matched_locations = 0
+    num_already_imported_locations = 0
 
     for filepath in outputs.iter_data_paths(
         ennrich_run_dir, suffix=STAGE_OUTPUT_SUFFIX[PipelineStage.ENRICH]
@@ -141,6 +143,20 @@ def run_load_to_vial(
                     )
                     continue
 
+                # Skip source locations that haven't changed since last load
+                source_loc = None
+                if source_locations:
+                    source_loc = source_locations.get(normalized_location.id)
+
+                    if source_loc:
+                        incoming_hash = normalize.calculate_content_hash(
+                            normalized_location
+                        )
+
+                        if incoming_hash == source_loc.content_hash:
+                            num_already_imported_locations += 1
+                            continue
+
                 match_action = None
                 if match_ids and normalized_location.id in match_ids:
                     match_action = load.ImportMatchAction(
@@ -154,9 +170,7 @@ def run_load_to_vial(
                 elif (enable_match or enable_create) and locations is not None:
                     # Match source locations if we are re-matching, or if we
                     # haven't matched this source location yet
-                    if enable_rematch or (
-                        matched_ids and normalized_location.id not in matched_ids
-                    ):
+                    if enable_rematch or not source_loc or not source_loc.matched:
                         match_action = _match_source_to_existing_locations(
                             normalized_location,
                             locations,
@@ -198,7 +212,9 @@ def run_load_to_vial(
                 )
             except HTTPError as e:
                 logger.warning(
-                    "Failed to import some source locations for %s in %s. Because this is action spans multiple remote calls, some locations may have been imported: %s",
+                    "Failed to import some source locations for %s in %s. "
+                    "Because this is action spans multiple remote calls, "
+                    "some locations may have been imported: %s",
                     filepath.name,
                     site_dir.name,
                     e,
@@ -215,23 +231,26 @@ def run_load_to_vial(
 
     if enable_rematch:
         logger.info(
-            "Imported %d source locations for %s (%d new, %d matched, %d unknown)",
+            "Imported %d source locations for %s "
+            "(%d new, %d matched, %d unknown) and skipped %d",
             num_imported_locations,
             site_dir.name,
             num_new_locations,
             num_match_locations,
             num_unknown_locations,
+            num_already_imported_locations,
         )
     else:
         logger.info(
             "Imported %d source locations for %s "
-            "(%d new, %d matched, %d unknown, %d had existing match)",
+            "(%d new, %d matched, %d unknown, %d had existing match) and skipped %d",
             num_imported_locations,
             site_dir.name,
             num_new_locations,
             num_match_locations,
             num_unknown_locations,
             num_already_matched_locations,
+            num_already_imported_locations,
         )
 
     return import_locations

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -36,6 +36,7 @@ def load_sites_to_vial(
     enable_match: bool,
     enable_create: bool,
     enable_rematch: bool,
+    enable_reimport: bool,
     match_ids: Optional[Dict[str, str]],
     create_ids: Optional[Collection[str]],
     candidate_distance: float,
@@ -52,8 +53,8 @@ def load_sites_to_vial(
             logger.info("Loading existing location from VIAL")
             locations = vial.retrieve_existing_locations_as_index(vial_http)
 
-            # Skip loading already matched if re-matching
-            if not enable_rematch:
+            # Skip loading already matched if re-matching and re-importing
+            if not enable_rematch and not enable_reimport:
                 logger.info("Loading already matched source locations from VIAL")
                 source_locations = vial.retrieve_source_location_hashes(vial_http)
 
@@ -69,6 +70,7 @@ def load_sites_to_vial(
                 enable_match=enable_match,
                 enable_create=enable_create,
                 enable_rematch=enable_rematch,
+                enable_reimport=enable_reimport,
                 match_ids=match_ids,
                 create_ids=create_ids,
                 candidate_distance=candidate_distance,
@@ -99,6 +101,7 @@ def run_load_to_vial(
     enable_match: bool = True,
     enable_create: bool = False,
     enable_rematch: bool = False,
+    enable_reimport: bool = False,
     match_ids: Optional[Dict[str, str]] = None,
     create_ids: Optional[Collection[str]] = None,
     candidate_distance: float = 0.6,
@@ -148,7 +151,7 @@ def run_load_to_vial(
                 if source_locations:
                     source_loc = source_locations.get(normalized_location.id)
 
-                    if source_loc:
+                    if not enable_reimport and source_loc:
                         incoming_hash = normalize.calculate_content_hash(
                             normalized_location
                         )

--- a/vaccine_feed_ingest/utils/normalize.py
+++ b/vaccine_feed_ingest/utils/normalize.py
@@ -1,12 +1,13 @@
 """
 Various tricks for matching source locations to product locations from VIAL
 """
+import hashlib
 import re
 from typing import List, Optional, Tuple
 
 import phonenumbers
 import url_normalize
-from vaccine_feed_ingest_schema import location as schema
+from vaccine_feed_ingest_schema import location
 from vaccine_feed_ingest_schema.location import VaccineProvider
 
 from .log import getLogger
@@ -236,7 +237,7 @@ def normalize_url(url: Optional[str]) -> Optional[str]:
 
 def normalize_phone(
     phone: Optional[str], contact_type: Optional[str] = None
-) -> Optional[List[schema.Contact]]:
+) -> Optional[List[location.Contact]]:
     if phone is None:
         return []
 
@@ -250,7 +251,7 @@ def normalize_phone(
     contacts = []
     for match in phonenumbers.PhoneNumberMatcher(phone, "US"):
         contacts.append(
-            schema.Contact(
+            location.Contact(
                 contact_type=contact_type,
                 phone=phonenumbers.format_number(
                     match.number, phonenumbers.PhoneNumberFormat.NATIONAL
@@ -258,3 +259,9 @@ def normalize_phone(
             )
         )
     return contacts
+
+
+def calculate_content_hash(loc: location.NormalizedLocation) -> str:
+    """Calculate a hash from the normalized content of a location without source data"""
+    loc_json = loc.json(exclude={"source"}, sort_keys=True)
+    return hashlib.md5(loc_json.encode()).hexdigest()


### PR DESCRIPTION
Calculate a content hash from the normalized location fields, and only import the source location if the hash is different.

This should greatly increase performance of loading new locations