### PR TITLE
SC: Fix error when normalizing locations

### DIFF
--- a/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/sc/arcgis/normalize.py
@@ -135,7 +135,20 @@ def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
 def _get_normalized_location(
     site: dict, timestamp: str
 ) -> Optional[schema.NormalizedLocation]:
-    if len(site["attributes"]["loc_name"]) > 256:
+    if site["attributes"] is None:
+        logger.error(
+            "Cannot normalize site data without an 'attributes' field: %s", site
+        )
+        return None
+    name = site["attributes"]["loc_name"]
+    if name is None:
+        logger.error(
+            "Cannot normalize site data without an 'attributes.loc_name' field: %s",
+            site,
+        )
+        return None
+    if len(name) > 256:
+        logger.error("Site name must have 256 characters or fewer; ignoring %s", name)
         return None
 
     # Contact parsing for this site is a little flaky. Ensure that a bug for
@@ -153,7 +166,7 @@ def _get_normalized_location(
 
     return schema.NormalizedLocation(
         id=_get_id(site),
-        name=site["attributes"]["loc_name"],
+        name=name,
         address=_get_address(site),
         location=schema.LatLng(
             latitude=site["geometry"]["y"],

--- a/vaccine_feed_ingest/utils/normalize.py
+++ b/vaccine_feed_ingest/utils/normalize.py
@@ -237,7 +237,7 @@ def normalize_url(url: Optional[str]) -> Optional[str]:
 
 def normalize_phone(
     phone: Optional[str], contact_type: Optional[str] = None
-) -> Optional[List[location.Contact]]:
+) -> List[location.Contact]:
     if phone is None:
         return []
 


### PR DESCRIPTION
| Key Details |
|-|
State: SC |
Site: arcgis |

## Notes
Defensive fix for normalize bug observed in PR checks on https://github.com/CAVaccineInventory/vaccine-feed-ingest/pull/659, e.g. [here](https://github.com/CAVaccineInventory/vaccine-feed-ingest/pull/659/checks?check_run_id=2616534722#step:11:212).

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
