### PR TITLE
parse street addres from GISCorps dataset using usaddress library

### DIFF
--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -261,10 +261,46 @@ def normalize_state_name(name: str) -> str:
 
 
 def apply_address_fixups(address: OrderedDict[str, str]) -> OrderedDict[str, str]:
+
+    if "PlaceName" in address and "StateName" in address:
+        problem_dakotas = ["Valley City, North", "Williston North", "Belle Fourche, South"]
+        if address["PlaceName"] in problem_dakotas and address["StateName"] == "Dakota":
+            pl_old = address["PlaceName"]
+            address["PlaceName"] = pl_old[:-5].strip()
+            address["StateName"] = pl_old[-5:] + " Dakota"
+
     if "StateName" in address:
         state = address["StateName"]
+
+        if state == "ND North Dakota":
+            state = "North Dakota"
+        elif state == "Mich.":
+            state = "Michigan"
+        elif state == "SR":
+            raise CustomBailError()
+
+        if state in ["Bay Arkansas", "Palestine Arkansas"]:
+            spl = state.split(" ")
+            state = spl[1]
+            address["PlaceName"] = (address.get("PlaceName") or "" + " " + spl[0]).strip()
+
         address["StateName"] = normalize_state_name(state)
 
+        if len(address["StateName"]) == 1:
+            del address["StateName"]
+
+        if address.get("StateName") in ["ANCHORAGE", "LAGOON", "C2", "IN SPRINGFIELD", "BAY", "JUNCTION", "JERSEY", "CAROLINA", "FE", "MEXICO", "OAKS", "GUAYAMA", "ISABELA", "HATILLO", "BAYAMÓN", "CAGUAS", "FAJARDO", "PONCE", "MAYAGÜEZ", "ISLANDS", "LIMA", "CLAYTON", "", "", "", ""]:
+
+            address["PlaceName"] = (address.get("PlaceName") or "" + " " + address["StateName"].lower()).strip()
+
+            del address["StateName"]
+
+        if address.get("StateName") == "ALA":
+            address["StateName"] = "AL"
+
+        if address.get("StateName") == "PA15068":
+            address["StateName"] = "PA"
+            address["ZipCode"] = "15068"
 
     if "ZipCode" in address:
         normalzip = normalize_zip(address["ZipCode"])

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -18,6 +18,10 @@ logger = getLogger(__file__)
 SOURCE_NAME = "us_giscorps_vaccine_providers"
 
 
+class CustomBailError(Exception):
+    pass
+
+
 def _get_availability(site: dict) -> schema.Availability:
     appt_only = site["attributes"]["appt_only"]
 
@@ -280,7 +284,7 @@ def _get_address(site):
         normalized = normalize_address(parsed)
 
         return normalized
-    except usaddress.RepeatedLabelError:
+    except (usaddress.RepeatedLabelError, CustomBailError):
         return None
 
 

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -206,8 +206,8 @@ def _get_address(site):
             zip=zipcode,
         )
     else:
-        print(addr_type)
-        print(addrDict)
+        # print(addr_type)
+        # print(addrDict)
 
         return None
 

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -256,6 +256,11 @@ def normalize_state_name(name: str) -> str:
 
 
 def apply_address_fixups(address: OrderedDict[str, str]) -> OrderedDict[str, str]:
+    if "StateName" in address:
+        state = address["StateName"]
+        address["StateName"] = normalize_state_name(state)
+
+
     if "ZipCode" in address:
         normalzip = normalize_zip(address["ZipCode"])
         if normalzip:

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -254,13 +254,22 @@ def normalize_state_name(name: str) -> str:
 
     return name.upper()
 
+
+def apply_address_fixups(address: OrderedDict[str, str]) -> OrderedDict[str, str]:
+    return address
+
+
 def _get_address(site):
+    try:
+        parsed = parse_address(site["attributes"]["fulladdr"])
 
-    parsed = parse_address(site["attributes"]["fulladdr"])
+        parsed = apply_address_fixups(parsed)
 
-    normalized = normalize_address(parsed)
+        normalized = normalize_address(parsed)
 
-    return normalized
+        return normalized
+    except usaddress.RepeatedLabelError:
+        return None
 
 
 def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLocation:

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -7,11 +7,16 @@ import pathlib
 import sys
 from typing import List, Optional, OrderedDict
 
+import usaddress
 from vaccine_feed_ingest_schema import location as schema
 
-import usaddress
 from vaccine_feed_ingest.utils.log import getLogger
-from vaccine_feed_ingest.utils.normalize import normalize_phone, parse_address, normalize_zip, normalize_address
+from vaccine_feed_ingest.utils.normalize import (
+    normalize_address,
+    normalize_phone,
+    normalize_zip,
+    parse_address,
+)
 
 logger = getLogger(__file__)
 
@@ -186,68 +191,68 @@ def normalize_state_name(name: str) -> str:
         return name
 
     us_state_abbrev = {
-        'Alabama': 'AL',
-        'Alaska': 'AK',
-        'American Samoa': 'AS',
-        'Arizona': 'AZ',
-        'Arkansas': 'AR',
-        'California': 'CA',
-        'Colorado': 'CO',
-        'Connecticut': 'CT',
-        'Delaware': 'DE',
-        'District of Columbia': 'DC',
-        'Florida': 'FL',
-        'Georgia': 'GA',
-        'Guam': 'GU',
-        'Hawaii': 'HI',
-        'Idaho': 'ID',
-        'Illinois': 'IL',
-        'Indiana': 'IN',
-        'Iowa': 'IA',
-        'Kansas': 'KS',
-        'Kentucky': 'KY',
-        'Louisiana': 'LA',
-        'Maine': 'ME',
-        'Maryland': 'MD',
-        'Massachusetts': 'MA',
-        'Michigan': 'MI',
-        'Minnesota': 'MN',
-        'Mississippi': 'MS',
-        'Missouri': 'MO',
-        'Montana': 'MT',
-        'Nebraska': 'NE',
-        'Nevada': 'NV',
-        'New Hampshire': 'NH',
-        'New Jersey': 'NJ',
-        'New Mexico': 'NM',
-        'New York': 'NY',
-        'North Carolina': 'NC',
-        'North Dakota': 'ND',
-        'Northern Mariana Islands': 'MP',
-        'Ohio': 'OH',
-        'Oklahoma': 'OK',
-        'Oregon': 'OR',
-        'Pennsylvania': 'PA',
-        'Puerto Rico': 'PR',
-        'Rhode Island': 'RI',
-        'South Carolina': 'SC',
-        'South Dakota': 'SD',
-        'Tennessee': 'TN',
-        'Texas': 'TX',
-        'Utah': 'UT',
-        'Vermont': 'VT',
-        'Virgin Islands': 'VI',
-        'Virginia': 'VA',
-        'Washington': 'WA',
-        'West Virginia': 'WV',
-        'Wisconsin': 'WI',
-        'Wyoming': 'WY'
+        "Alabama": "AL",
+        "Alaska": "AK",
+        "American Samoa": "AS",
+        "Arizona": "AZ",
+        "Arkansas": "AR",
+        "California": "CA",
+        "Colorado": "CO",
+        "Connecticut": "CT",
+        "Delaware": "DE",
+        "District of Columbia": "DC",
+        "Florida": "FL",
+        "Georgia": "GA",
+        "Guam": "GU",
+        "Hawaii": "HI",
+        "Idaho": "ID",
+        "Illinois": "IL",
+        "Indiana": "IN",
+        "Iowa": "IA",
+        "Kansas": "KS",
+        "Kentucky": "KY",
+        "Louisiana": "LA",
+        "Maine": "ME",
+        "Maryland": "MD",
+        "Massachusetts": "MA",
+        "Michigan": "MI",
+        "Minnesota": "MN",
+        "Mississippi": "MS",
+        "Missouri": "MO",
+        "Montana": "MT",
+        "Nebraska": "NE",
+        "Nevada": "NV",
+        "New Hampshire": "NH",
+        "New Jersey": "NJ",
+        "New Mexico": "NM",
+        "New York": "NY",
+        "North Carolina": "NC",
+        "North Dakota": "ND",
+        "Northern Mariana Islands": "MP",
+        "Ohio": "OH",
+        "Oklahoma": "OK",
+        "Oregon": "OR",
+        "Pennsylvania": "PA",
+        "Puerto Rico": "PR",
+        "Rhode Island": "RI",
+        "South Carolina": "SC",
+        "South Dakota": "SD",
+        "Tennessee": "TN",
+        "Texas": "TX",
+        "Utah": "UT",
+        "Vermont": "VT",
+        "Virgin Islands": "VI",
+        "Virginia": "VA",
+        "Washington": "WA",
+        "West Virginia": "WV",
+        "Wisconsin": "WI",
+        "Wyoming": "WY",
     }
 
     name = name.strip()
     name = name.replace(".", "")
 
-    #capitalize the first letter of each word in cases where a state name is provided
+    # capitalize the first letter of each word in cases where a state name is provided
     spl = name.split(" ")
     if len(spl) > 1:
         " ".join([word.capitalize() for word in spl])
@@ -263,7 +268,11 @@ def normalize_state_name(name: str) -> str:
 def apply_address_fixups(address: OrderedDict[str, str]) -> OrderedDict[str, str]:
 
     if "PlaceName" in address and "StateName" in address:
-        problem_dakotas = ["Valley City, North", "Williston North", "Belle Fourche, South"]
+        problem_dakotas = [
+            "Valley City, North",
+            "Williston North",
+            "Belle Fourche, South",
+        ]
         if address["PlaceName"] in problem_dakotas and address["StateName"] == "Dakota":
             pl_old = address["PlaceName"]
             address["PlaceName"] = pl_old[:-5].strip()
@@ -282,16 +291,47 @@ def apply_address_fixups(address: OrderedDict[str, str]) -> OrderedDict[str, str
         if state in ["Bay Arkansas", "Palestine Arkansas"]:
             spl = state.split(" ")
             state = spl[1]
-            address["PlaceName"] = (address.get("PlaceName") or "" + " " + spl[0]).strip()
+            address["PlaceName"] = (
+                address.get("PlaceName") or "" + " " + spl[0]
+            ).strip()
 
         address["StateName"] = normalize_state_name(state)
 
         if len(address["StateName"]) == 1:
             del address["StateName"]
 
-        if address.get("StateName") in ["ANCHORAGE", "LAGOON", "C2", "IN SPRINGFIELD", "BAY", "JUNCTION", "JERSEY", "CAROLINA", "FE", "MEXICO", "OAKS", "GUAYAMA", "ISABELA", "HATILLO", "BAYAMÓN", "CAGUAS", "FAJARDO", "PONCE", "MAYAGÜEZ", "ISLANDS", "LIMA", "CLAYTON", "", "", "", ""]:
+        if address.get("StateName") in [
+            "ANCHORAGE",
+            "LAGOON",
+            "C2",
+            "IN SPRINGFIELD",
+            "BAY",
+            "JUNCTION",
+            "JERSEY",
+            "CAROLINA",
+            "FE",
+            "MEXICO",
+            "OAKS",
+            "GUAYAMA",
+            "ISABELA",
+            "HATILLO",
+            "BAYAMÓN",
+            "CAGUAS",
+            "FAJARDO",
+            "PONCE",
+            "MAYAGÜEZ",
+            "ISLANDS",
+            "LIMA",
+            "CLAYTON",
+            "",
+            "",
+            "",
+            "",
+        ]:
 
-            address["PlaceName"] = (address.get("PlaceName") or "" + " " + address["StateName"].lower()).strip()
+            address["PlaceName"] = (
+                address.get("PlaceName") or "" + " " + address["StateName"].lower()
+            ).strip()
 
             del address["StateName"]
 

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -175,6 +175,85 @@ def try_get_lat_long(site):
     return location
 
 
+def normalize_state_name(name: str) -> str:
+
+    if name is None:
+        return name
+
+    us_state_abbrev = {
+        'Alabama': 'AL',
+        'Alaska': 'AK',
+        'American Samoa': 'AS',
+        'Arizona': 'AZ',
+        'Arkansas': 'AR',
+        'California': 'CA',
+        'Colorado': 'CO',
+        'Connecticut': 'CT',
+        'Delaware': 'DE',
+        'District of Columbia': 'DC',
+        'Florida': 'FL',
+        'Georgia': 'GA',
+        'Guam': 'GU',
+        'Hawaii': 'HI',
+        'Idaho': 'ID',
+        'Illinois': 'IL',
+        'Indiana': 'IN',
+        'Iowa': 'IA',
+        'Kansas': 'KS',
+        'Kentucky': 'KY',
+        'Louisiana': 'LA',
+        'Maine': 'ME',
+        'Maryland': 'MD',
+        'Massachusetts': 'MA',
+        'Michigan': 'MI',
+        'Minnesota': 'MN',
+        'Mississippi': 'MS',
+        'Missouri': 'MO',
+        'Montana': 'MT',
+        'Nebraska': 'NE',
+        'Nevada': 'NV',
+        'New Hampshire': 'NH',
+        'New Jersey': 'NJ',
+        'New Mexico': 'NM',
+        'New York': 'NY',
+        'North Carolina': 'NC',
+        'North Dakota': 'ND',
+        'Northern Mariana Islands': 'MP',
+        'Ohio': 'OH',
+        'Oklahoma': 'OK',
+        'Oregon': 'OR',
+        'Pennsylvania': 'PA',
+        'Puerto Rico': 'PR',
+        'Rhode Island': 'RI',
+        'South Carolina': 'SC',
+        'South Dakota': 'SD',
+        'Tennessee': 'TN',
+        'Texas': 'TX',
+        'Utah': 'UT',
+        'Vermont': 'VT',
+        'Virgin Islands': 'VI',
+        'Virginia': 'VA',
+        'Washington': 'WA',
+        'West Virginia': 'WV',
+        'Wisconsin': 'WI',
+        'Wyoming': 'WY'
+    }
+
+    name = name.strip()
+    name = name.replace(".", "")
+
+    #capitalize the first letter of each word in cases where a state name is provided
+    spl = name.split(" ")
+    if len(spl) > 1:
+        " ".join([word.capitalize() for word in spl])
+    else:
+        name = name.lower().capitalize()
+
+    if name in us_state_abbrev:
+        return us_state_abbrev[name]
+
+    return name.upper()
+
 def _get_address(site):
 
     parsed = parse_address(site["attributes"]["fulladdr"])

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -5,10 +5,11 @@ import json
 import os
 import pathlib
 import sys
-from typing import List, Optional
+from typing import List, Optional, OrderedDict
 
 from vaccine_feed_ingest_schema import location as schema
 
+import usaddress
 from vaccine_feed_ingest.utils.log import getLogger
 from vaccine_feed_ingest.utils.normalize import normalize_phone, parse_address, normalize_zip, normalize_address
 

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -256,6 +256,13 @@ def normalize_state_name(name: str) -> str:
 
 
 def apply_address_fixups(address: OrderedDict[str, str]) -> OrderedDict[str, str]:
+    if "ZipCode" in address:
+        normalzip = normalize_zip(address["ZipCode"])
+        if normalzip:
+            address["ZipCode"] = normalzip
+        else:
+            del address["ZipCode"]
+
     return address
 
 

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -323,10 +323,6 @@ def apply_address_fixups(address: OrderedDict[str, str]) -> OrderedDict[str, str
             "ISLANDS",
             "LIMA",
             "CLAYTON",
-            "",
-            "",
-            "",
-            "",
         ]:
 
             address["PlaceName"] = (

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -11,7 +11,7 @@ import usaddress
 from vaccine_feed_ingest_schema import location as schema
 
 from vaccine_feed_ingest.utils.log import getLogger
-from vaccine_feed_ingest.utils.normalize import normalize_phone
+from vaccine_feed_ingest.utils.normalize import normalize_phone, normalize_zip
 
 logger = getLogger(__file__)
 
@@ -195,25 +195,8 @@ def _get_address(site):
     state = addrDict.get("Statename")
     zipcode = addrDict.get("ZipCode")
 
-    if zipcode is not None and len(zipcode) < 5:
-        zipcode = None
+    zipcode = normalize_zip(zipcode)
 
-    if zipcode is not None and zipcode.isalnum() and not zipcode.isnumeric():
-        zipcode = "".join(ch for ch in zipcode if ch.isnumeric() or ch == "-")
-
-    if zipcode is not None and len(zipcode) < 10:
-        zipcode = None
-
-    if zipcode is not None and len(zipcode.split("-")) > 2:
-        zipcode = None
-
-    # zip = site["attributes"]["fulladdr"][-5:]
-    # zip = zip if zip.isnumeric() else None
-
-    # city_state_zip = addrsplit[1].split(" ") if try_get_list(addrsplit, 1) else None
-
-    # state = site["attributes"]["State"] or None
-    # state = state.strip() if state is not None else None
     if addr_type == "Street Address":
         return schema.Address(
             street1=street,

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -5,14 +5,13 @@ import json
 import os
 import pathlib
 import sys
-import string
 from typing import List, Optional
 
+import usaddress
 from vaccine_feed_ingest_schema import location as schema
 
 from vaccine_feed_ingest.utils.log import getLogger
 from vaccine_feed_ingest.utils.normalize import normalize_phone
-import usaddress
 
 logger = getLogger(__file__)
 
@@ -178,29 +177,35 @@ def try_get_lat_long(site):
 
 
 def _get_address(site):
-    # addrsplit = 
+    # addrsplit =
     addrDict, addr_type = None, None
     try:
         addrDict, addr_type = usaddress.tag(site["attributes"]["fulladdr"])
     except Exception:
         return None
 
-    street = (addrDict.get('AddressNumber') or "") + " " + (addrDict.get('StreetName') or "") + " " + (addrDict.get('StreetNamePostType') or "")
-    place = addrDict.get('PlaceName')
-    state = addrDict.get('Statename')
-    zipcode = addrDict.get('ZipCode')
+    street = (
+        (addrDict.get("AddressNumber") or "")
+        + " "
+        + (addrDict.get("StreetName") or "")
+        + " "
+        + (addrDict.get("StreetNamePostType") or "")
+    )
+    place = addrDict.get("PlaceName")
+    state = addrDict.get("Statename")
+    zipcode = addrDict.get("ZipCode")
 
     if zipcode is not None and len(zipcode) < 5:
         zipcode = None
 
     if zipcode is not None and zipcode.isalnum() and not zipcode.isnumeric():
-        zipcode = ''.join(ch for ch in zipcode if ch.isnumeric() or ch == "-")
+        zipcode = "".join(ch for ch in zipcode if ch.isnumeric() or ch == "-")
 
     if zipcode is not None and len(zipcode) < 10:
         zipcode = None
 
     if zipcode is not None and len(zipcode.split("-")) > 2:
-        zipcode = None 
+        zipcode = None
 
     # zip = site["attributes"]["fulladdr"][-5:]
     # zip = zip if zip.isnumeric() else None
@@ -222,6 +227,7 @@ def _get_address(site):
         print(addrDict)
 
         return None
+
 
 def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLocation:
 


### PR DESCRIPTION

| Key Details |
|-|
State: us |
Site: giscorps_vaccine_providers |

## Notes
update parsing to attempt to parse addresses.

There seem to still be many addresses that are ambiguous, but this gets the majority that are fully-qualified

## Before Opening a PR
- [ X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [ X] I ran auto-formatting: `poetry run tox -e lint-fix`
