### PR TITLE
chore: page geocodio calls in batches of 5k

### DIFF
--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -1,4 +1,4 @@
-from typing import Iterator
+from typing import Dict, Iterator
 
 from vaccine_feed_ingest.utils import misc
 
@@ -24,5 +24,30 @@ def test_batch():
         assert len(group_list) <= 3
 
         final_items.extend(group_list)
+
+    assert orig_items == final_items
+
+
+def test_dict_batch():
+    orig_items = {1: "a", 2: "b", 3: "c", 4: "d", 5: "e"}
+
+    batched_iter = misc.dict_batch(orig_items, 3)
+
+    assert batched_iter is not None
+    assert isinstance(batched_iter, Iterator)
+
+    batched_list = list(batched_iter)
+    assert len(batched_list) == 2
+
+    final_items: Dict[int, str] = {}
+    for group_dict in batched_list:
+        assert group_dict is not None
+        assert isinstance(group_dict, dict)
+
+        print(group_dict)
+        assert len(group_dict) <= 3
+
+        for k, v in group_dict.items():
+            final_items[k] = v
 
     assert orig_items == final_items

--- a/vaccine_feed_ingest/utils/misc.py
+++ b/vaccine_feed_ingest/utils/misc.py
@@ -1,6 +1,6 @@
 """Miscellaneous python utils"""
 import itertools
-from typing import Iterable, Iterator
+from typing import Any, Dict, Iterable, Iterator
 
 
 def batch(iterable: Iterable, size: int) -> Iterator[Iterator]:
@@ -14,3 +14,17 @@ def batch(iterable: Iterable, size: int) -> Iterator[Iterator]:
             return
 
         yield iter(batch_iterator)
+
+
+def dict_batch(dictionary: Dict[Any, Any], size: int) -> Iterator[Dict[Any, Any]]:
+    iterator = iter(dictionary)
+
+    while True:
+        batch_iterator = list(itertools.islice(iterator, size))
+
+        if not batch_iterator:
+            return
+
+        batch = {k: dictionary[k] for k in batch_iterator}
+
+        yield batch


### PR DESCRIPTION
Geocodio's python library does not handle paging api calls, and they have a maximum of 10k records per call. Process geocode requests in batches of 5k to stay well under this limit.