### PR TITLE
Normalize Vaccinate NJ for NJ

### DIFF
--- a/vaccine_feed_ingest/runners/nj/vaccinate_nj/normalize.py
+++ b/vaccine_feed_ingest/runners/nj/vaccinate_nj/normalize.py
@@ -46,7 +46,12 @@ def normalize_entry(vaccination_site_dict):
     if vaccination_site_dict["phone"]:
         normalized_dict["contact"].append({"phone": vaccination_site_dict["phone"]})
     if vaccination_site_dict["url"]:
-        normalized_dict["contact"].append({"url": vaccination_site_dict["url"]})
+        if vaccination_site_dict["url"][-1] == "#":
+            # HACK: not sure why trailing '#' makes the url invalid.
+            url = vaccination_site_dict["url"][:-1]
+        else:
+            url = vaccination_site_dict["url"]
+        normalized_dict["contact"].append({"website": url})
     return normalized_dict
 
 

--- a/vaccine_feed_ingest/runners/nj/vaccinate_nj/normalize.py
+++ b/vaccine_feed_ingest/runners/nj/vaccinate_nj/normalize.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+import pathlib
+import sys
+
+import ndjson
+
+output_path = pathlib.Path(sys.argv[1])
+input_path = pathlib.Path(sys.argv[2])
+
+def normalize_entry(vaccination_site_dict):
+    normalized_dict = {
+        "id": "vaccinate_nj:" + vaccination_site_dict["id"],
+        "name": vaccination_site_dict["name"],
+        "address": {
+            "street1": vaccination_site_dict["address"],
+            "city": vaccination_site_dict["city"],
+            "state": "NJ",
+            "zip": vaccination_site_dict["zipCode"]
+        },
+        "location": {
+            "latitude": vaccination_site_dict["geoCode"]["latitude"],
+            "longitude": vaccination_site_dict["geoCode"]["longitude"]
+        },
+        "languages": [
+            "en"
+        ],
+        "availability": {
+            "drop_in": "Walk-in" in vaccination_site_dict["scheduling"],  # scheduling is a list of enum strings
+            "appointments": vaccination_site_dict["availabilityStatus"] == "Available"
+        },
+        "active": True,
+        "source": {
+            "source": "vaccinate_nj",
+            "id": vaccination_site_dict["id"],
+            "fetched_from_uri": "https://c19vaccinelocatornj.info/api/v1/vaccine/locations/page",
+            "fetched_at": None, # TODO: not sure how to get this data from parsed data?
+            "published_at": vaccination_site_dict["lastCheckedDate"],
+            "data": vaccination_site_dict
+        }
+    }
+    if vaccination_site_dict["phone"] or vaccination_site_dict["url"]:
+        normalized_dict["contact"] = []
+    if vaccination_site_dict["phone"]:
+        normalized_dict["contact"].append(
+            {
+                "phone": vaccination_site_dict["phone"]
+            }
+        )
+    if vaccination_site_dict["url"]:
+        normalized_dict["contact"].append(
+            {
+                "url": vaccination_site_dict["url"]
+            }
+        )
+    return normalized_dict
+
+
+with open(input_path / "data.parsed.ndjson", "r") as f:
+    file_contents = ndjson.load(f)
+    output_json = [
+        normalize_entry(entry) for entry in file_contents
+    ]
+with open(output_path / "data.normalized.ndjson", "w") as f:
+    ndjson.dump(output_json, f)

--- a/vaccine_feed_ingest/runners/nj/vaccinate_nj/normalize.py
+++ b/vaccine_feed_ingest/runners/nj/vaccinate_nj/normalize.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
 import datetime
+import os
 import pathlib
 import sys
 
 import ndjson
-import os
 
 output_dir = pathlib.Path(sys.argv[1])
 input_dir = pathlib.Path(sys.argv[2])
 timestamp = datetime.datetime.utcnow().isoformat()
+
 
 def normalize_entry(vaccination_site_dict):
     normalized_dict = {
@@ -54,6 +55,7 @@ def normalize_entry(vaccination_site_dict):
             url = vaccination_site_dict["url"]
         normalized_dict["contact"].append({"website": url})
     return normalized_dict
+
 
 json_filepaths = input_dir.glob("*.ndjson")
 for in_filepath in json_filepaths:

--- a/vaccine_feed_ingest/runners/nj/vaccinate_nj/normalize.py
+++ b/vaccine_feed_ingest/runners/nj/vaccinate_nj/normalize.py
@@ -8,6 +8,7 @@ import ndjson
 output_path = pathlib.Path(sys.argv[1])
 input_path = pathlib.Path(sys.argv[2])
 
+
 def normalize_entry(vaccination_site_dict):
     normalized_dict = {
         "id": "vaccinate_nj:" + vaccination_site_dict["id"],
@@ -16,50 +17,41 @@ def normalize_entry(vaccination_site_dict):
             "street1": vaccination_site_dict["address"],
             "city": vaccination_site_dict["city"],
             "state": "NJ",
-            "zip": vaccination_site_dict["zipCode"]
+            "zip": vaccination_site_dict["zipCode"],
         },
         "location": {
             "latitude": vaccination_site_dict["geoCode"]["latitude"],
-            "longitude": vaccination_site_dict["geoCode"]["longitude"]
+            "longitude": vaccination_site_dict["geoCode"]["longitude"],
         },
-        "languages": [
-            "en"
-        ],
+        "languages": ["en"],
         "availability": {
-            "drop_in": "Walk-in" in vaccination_site_dict["scheduling"],  # scheduling is a list of enum strings
-            "appointments": vaccination_site_dict["availabilityStatus"] == "Available"
+            "drop_in": "Walk-in"
+            in vaccination_site_dict[
+                "scheduling"
+            ],  # scheduling is a list of enum strings
+            "appointments": vaccination_site_dict["availabilityStatus"] == "Available",
         },
         "active": True,
         "source": {
             "source": "vaccinate_nj",
             "id": vaccination_site_dict["id"],
             "fetched_from_uri": "https://c19vaccinelocatornj.info/api/v1/vaccine/locations/page",
-            "fetched_at": None, # TODO: not sure how to get this data from parsed data?
+            "fetched_at": None,  # TODO: not sure how to get this data from parsed data?
             "published_at": vaccination_site_dict["lastCheckedDate"],
-            "data": vaccination_site_dict
-        }
+            "data": vaccination_site_dict,
+        },
     }
     if vaccination_site_dict["phone"] or vaccination_site_dict["url"]:
         normalized_dict["contact"] = []
     if vaccination_site_dict["phone"]:
-        normalized_dict["contact"].append(
-            {
-                "phone": vaccination_site_dict["phone"]
-            }
-        )
+        normalized_dict["contact"].append({"phone": vaccination_site_dict["phone"]})
     if vaccination_site_dict["url"]:
-        normalized_dict["contact"].append(
-            {
-                "url": vaccination_site_dict["url"]
-            }
-        )
+        normalized_dict["contact"].append({"url": vaccination_site_dict["url"]})
     return normalized_dict
 
 
 with open(input_path / "data.parsed.ndjson", "r") as f:
     file_contents = ndjson.load(f)
-    output_json = [
-        normalize_entry(entry) for entry in file_contents
-    ]
+    output_json = [normalize_entry(entry) for entry in file_contents]
 with open(output_path / "data.normalized.ndjson", "w") as f:
     ndjson.dump(output_json, f)


### PR DESCRIPTION
# <!-- <stage> <site> for <state> (e.g.,  Normalize ArcGIS for MD) -->

| Key Details |
|-|
| Resolves #699 |
State: NJ |
Site: Vaccinate NJ |

## Notes
All issues resolved

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```json
{"id": "vaccinate_nj:8465a5f6-9638-4cb8-9c88-d3612e7e8ee4", "name": "Adlers Pharmacy LTC", "address": {"street1": "100 Dobbs Lane Suite 205", "city": "Cherry Hill", "state": "NJ", "zip": "08034"}, "location": {"latitude": 39.8835179, "longitude": -75.00599559999999}, "languages": ["en"], "availability": {"drop_in": false, "appointments": true}, "active": true, "source": {"source": "vaccinate_nj", "id": "8465a5f6-9638-4cb8-9c88-d3612e7e8ee4", "fetched_from_uri": "https://c19vaccinelocatornj.info/api/v1/vaccine/locations/page", "fetched_at": "2021-05-31T17:31:39.460954", "published_at": "2021-04-09T16:21:06Z", "data": {"name": "Adlers Pharmacy LTC", "id": "8465a5f6-9638-4cb8-9c88-d3612e7e8ee4", "city": "Cherry Hill", "zipCode": "08034", "county": "Camden", "url": "https://covidvaccine.nj.gov", "type": "Pharmacy", "availabilityStatus": "Available", "availabilityChangedDate": "2021-04-10T23:37:58Z", "address": "100 Dobbs Lane Suite 205", "phone": null, "createdDate": "2021-04-10T23:36:08Z", "updatedDate": "2021-04-10T23:37:58Z", "scheduling": ["NJ VSS"], "lastCheckedDate": "2021-04-09T16:21:06Z", "eligibility": "State Wide", "geoCode": {"latitude": 39.8835179, "longitude": -75.00599559999999, "type": "ROOFTOP"}}}, "contact": [{"website": "https://covidvaccine.nj.gov"}]}
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
