### PR TITLE
AL: Follow up refactoring to Jefferson County normalize step

### DIFF
--- a/vaccine_feed_ingest/runners/al/jefferson/normalize.py
+++ b/vaccine_feed_ingest/runners/al/jefferson/normalize.py
@@ -38,6 +38,9 @@ _APPOINTMENTS_REGEX = re.compile(r"Make an appointment here.*")
 _IGNORE_PREFIXES = [
     r"Alabama Department of Public Health \(ADPH\)",
     r"Centers for Disease Control \(CDC\)",
+    # Assume a site with this line is covered by another entry
+    # titled "Make an appointment"
+    r"Find a location near you",
 ]
 _IGNORE_REGEX = re.compile(r"(" + "|".join(_IGNORE_PREFIXES) + r"):?")
 # Regex matching text that should not be used as the site name,

--- a/vaccine_feed_ingest/runners/al/jefferson/normalize.py
+++ b/vaccine_feed_ingest/runners/al/jefferson/normalize.py
@@ -5,7 +5,7 @@ import pathlib
 import re
 import sys
 from hashlib import md5
-from typing import Dict, List, Optional, Text
+from typing import Dict, List, Optional, Text, Tuple
 
 from vaccine_feed_ingest_schema import location as schema
 
@@ -35,9 +35,11 @@ _COMBINED_ADDRESS_REGEX = re.compile(
 _DROP_IN_REGEX = re.compile(r"No appointments? necessary.*")
 _APPOINTMENTS_REGEX = re.compile(r"Make an appointment here.*")
 # Regex matching the names of entries to be ignored entirely.
-_IGNORE_REGEX = re.compile(
-    r"(Alabama Department of Public Health \(ADPH\)|Centers for Disease Control \(CDC\)):?"
-)
+_IGNORE_PREFIXES = [
+    r"Alabama Department of Public Health \(ADPH\)",
+    r"Centers for Disease Control \(CDC\)",
+]
+_IGNORE_REGEX = re.compile(r"(" + "|".join(_IGNORE_PREFIXES) + r"):?")
 # Regex matching text that should not be used as the site name,
 # although we want to include the site itself.
 _IGNORE_NAME_REGEX = re.compile(r".*Locations to be determined.*")
@@ -48,17 +50,6 @@ def _make_placeholder_location(entry: dict) -> schema.NormalizedLocation:
     the given `entry` as source data, and all other fields empty."""
     source = _make_placeholder_source(entry)
     return schema.NormalizedLocation(id=_make_site_id(source), source=source)
-
-
-def _start_new_site(
-    current_site: schema.NormalizedLocation,
-    sites: List[schema.NormalizedLocation],
-    entry: dict,
-) -> schema.NormalizedLocation:
-    """Adds `current_site` to `sites` and returns a fresh site object."""
-    sites.append(current_site)
-    logger.debug("Recording current site and starting a new one: %s", current_site)
-    return _make_placeholder_location(entry)
 
 
 def _add_id(site: schema.NormalizedLocation) -> None:
@@ -119,9 +110,201 @@ def _add_website_and_provider(site: schema.NormalizedLocation, entry: dict) -> N
         site.parent_organization = _lookup_provider(website)
 
 
+def _finalize_site(site: schema.NormalizedLocation, entry: dict) -> None:
+    """Adds website, provider, and ID information to the given `site`."""
+    # Add the website and provider name, if we have it.
+    _add_website_and_provider(site, entry)
+    # Generate real IDs, now we have all the site information.
+    _add_id(site)
+
+
+def _get_combined_address(detail: Text) -> Optional[Tuple[Text, Text, Text]]:
+    """Gets a tuple (street address, city, zip) from `detail`, if it is a
+    complete single-line address. Otherwise returns `None`."""
+    if (combined_match := _COMBINED_ADDRESS_REGEX.match(detail)) is not None:
+        [street_address, city, zip] = combined_match.groups()[0:3]
+        logger.debug(
+            "One-line address '%s' split into address: '%s' city: '%s' zip: '%s'",
+            detail,
+            street_address,
+            city,
+            zip,
+        )
+        return street_address, city, zip
+    return None
+
+
+def _is_street_address(detail: Text) -> bool:
+    if _STREET_ADDRESS_REGEX.match(detail) is not None:
+        logger.debug("Street address: %s", detail)
+        return True
+    return False
+
+
+def _get_city_zip(detail: Text) -> Optional[Tuple[Text, Text]]:
+    """Gets a tuple `(city, zip)` from `detail`, if it contains the
+    city+state+zip component of an Alabama address. Otherwise returns `None`."""
+    if (city_state_zip_match := _CITY_STATE_ZIP_REGEX.match(detail)) is not None:
+        # Assume the state is always AL
+        [city, zip] = city_state_zip_match.groups()[0:2]
+        logger.debug("City, state, zip: %s -> city %s, zip %s", detail, city, zip)
+        return city, zip
+    return None
+
+
+def _is_phone(detail: Text) -> bool:
+    if _PHONE_NUMBER_REGEX.match(detail) is not None:
+        logger.debug("Phone: %s", detail)
+        return True
+    return False
+
+
+def _is_drop_in(detail: Text) -> bool:
+    if _DROP_IN_REGEX.match(detail) is not None:
+        logger.debug("Availability = drop in: %s", detail)
+        return True
+    return False
+
+
+def _is_appointments(detail: Text) -> bool:
+    if _APPOINTMENTS_REGEX.match(detail) is not None:
+        logger.debug("Availability = appt: %s", detail)
+        return True
+    return False
+
+
+def _should_ignore(detail: Text) -> bool:
+    """Whether the presence of `detail` indicates a generic parsed entry
+    that is unlikely to be a vaccine site, and should be ignored entirely."""
+    if _IGNORE_REGEX.match(detail) is not None:
+        logger.debug("Ignoring generic entry: %s", detail)
+        return True
+    return False
+
+
+class SiteBuilder:
+    """
+    Stateful builder to create a list of normalized vaccine sites
+    for a single entry from the parse step.
+    This is necessary because a single parsed entry may actually hold
+    information about multiple vaccine sites for the same provider.
+
+    Maintains a list of sites seen so far,
+    and a current site to which incoming details are added.
+    If incoming details are already present on the current site,
+    the builder will start a new site to record those details.
+    """
+
+    _sites: List[schema.NormalizedLocation]
+    _entry: dict
+    _current_site: schema.NormalizedLocation
+
+    def __init__(self, entry: dict) -> None:
+        super().__init__()
+        self._sites = []
+        self._entry = entry
+        self.fresh_site()
+
+    def fresh_site(self) -> None:
+        """Resets the current site to a fresh placeholder site."""
+        logger.debug("Starting a fresh site")
+        self._current_site = _make_placeholder_location(self._entry)
+
+    def next_site(self) -> None:
+        """Saves the current site and starts a fresh placeholder site."""
+        logger.debug("Recording current site: %s", self._current_site)
+        self._sites.append(self._current_site)
+        self.fresh_site()
+
+    def build_sites(self) -> List[schema.NormalizedLocation]:
+        """Returns the final list of normalized sites from this builder."""
+        # Include the last processed site.
+        if self._current_site_has_info():
+            self._sites.append(self._current_site)
+        for site in self._sites:
+            _finalize_site(site, self._entry)
+        return self._sites
+
+    def add_address_details(
+        self,
+        street_address: Optional[Text] = None,
+        city: Optional[Text] = None,
+        zip: Optional[Text] = None,
+    ) -> None:
+        """Adds the given address information to the current site.
+        If the current site already has one of the provided fields,
+        then starts a fresh site before recording the information.
+        """
+        # Start a new site if necessary.
+        address = self._current_site.address
+        if address and (
+            (street_address and address.street1)
+            or (city and address.city)
+            or (zip and address.zip)
+        ):
+            self.next_site()
+
+        # Create an Address object.
+        site = self._current_site
+        site.address = site.address or schema.Address(state="AL")
+        # Add the given details.
+        if street_address is not None:
+            site.address.street1 = street_address
+        if city is not None:
+            site.address.city = city
+        if zip is not None:
+            site.address.zip = normalize_zip(zip)
+
+    def add_generic_detail(self, detail: Text) -> None:
+        """Adds the given generic detail to the current site,
+        as the site name if suitable, or an additional note otherwise."""
+        if self._current_site.name or _IGNORE_NAME_REGEX.match(detail) is not None:
+            self.add_note(detail)
+        else:
+            self.add_name(detail)
+
+    def _current_site_has_info(self) -> bool:
+        """Whether the current site object has non-trivial information."""
+        site = self._current_site
+        return site.address or site.availability or site.name or site.contact
+
+    def add_name(self, detail: Text) -> None:
+        """Adds the given name to the current site."""
+        logger.debug("Site name: %s", detail)
+        self._current_site.name = detail
+
+    def add_note(self, note: Text) -> None:
+        """Adds the given note to the current site."""
+        logger.debug("Additional note: %s", note)
+        site = self._current_site
+        site.notes = site.notes or []
+        site.notes.append(note)
+
+    def add_availability(
+        self,
+        drop_in: Optional[bool] = None,
+        appointments: Optional[bool] = None,
+    ) -> None:
+        """Adds the given availability information to the current site."""
+        site = self._current_site
+        site.availability = site.availability or schema.Availability()
+        if drop_in is not None:
+            site.availability.drop_in = drop_in
+        if appointments is not None:
+            site.availability.appointments = appointments
+
+    def add_phone(self, phone: Text) -> None:
+        """Adds the given phone number to the current site."""
+        # It's ok to have multiple phone numbers,
+        # so no need to start fresh if we have a phone number already.
+        site = self._current_site
+        site.contact = site.contact or []
+        site.contact.extend(normalize_phone(phone, contact_type="booking"))
+
+
 def normalize(entry: dict) -> List[schema.NormalizedLocation]:
     """Gets a list of normalized vaccine site objects from a single parsed JSON entry."""
-    details = entry.get("details", [])
+    details: List[Text] = entry.get("details", [])
     # The details list can be in one of the following forms,
     # and may contain info about multiple sites:
     # [combined address, optional phone]+
@@ -129,97 +312,40 @@ def normalize(entry: dict) -> List[schema.NormalizedLocation]:
     # The parsed JSON has relatively little information about
     # provider names, because these are images in the original document.
 
-    # Process each detail, maintaining a current site (whose details we update)
-    # and a running list of processed sites.
-    sites: List[schema.NormalizedLocation] = []
-    current_site: schema.NormalizedLocation = _make_placeholder_location(entry)
+    # Process each detail, building up a list of sites.
+    site_builder = SiteBuilder(entry)
     for detail in details:
         # Trim whitespace and commas
         detail = detail.strip(" \t\n\r,")
         # Might be the entire address
-        if (combined_match := _COMBINED_ADDRESS_REGEX.match(detail)) is not None:
-            [street_address, city, zip] = combined_match.groups()[0:3]
-            logger.debug(
-                "One-line address '%s' split into address: '%s' city: '%s' zip: '%s'",
-                detail,
-                street_address,
-                city,
-                zip,
-            )
-            if current_site.address:
-                current_site = _start_new_site(current_site, sites, entry)
-            current_site.address = schema.Address(
-                street1=street_address, city=city, state="AL", zip=normalize_zip(zip)
+        if combined_address := _get_combined_address(detail):
+            street_address, city, zip = combined_address
+            site_builder.add_address_details(
+                street_address=street_address, city=city, zip=zip
             )
         # Or one component of site info
-        elif _STREET_ADDRESS_REGEX.match(detail) is not None:
-            logger.debug("Street address: %s", detail)
-            if current_site.address and current_site.address.street1:
-                current_site = _start_new_site(current_site, sites, entry)
-            current_site.address = current_site.address or schema.Address(state="AL")
-            current_site.address.street1 = detail
-        elif (city_state_zip_match := _CITY_STATE_ZIP_REGEX.match(detail)) is not None:
-            logger.debug("City, state, zip: %s", detail)
+        elif _is_street_address(detail):
+            site_builder.add_address_details(street_address=detail)
+        elif city_zip := _get_city_zip(detail):
             # Assume the state is always AL
-            [city, zip] = city_state_zip_match.groups()[0:2]
-            if current_site.address and (
-                current_site.address.city or current_site.address.zip
-            ):
-                current_site = _start_new_site(current_site, sites, entry)
-            current_site.address = current_site.address or schema.Address(state="AL")
-            current_site.address.city = city
-            current_site.address.zip = normalize_zip(zip)
-        elif _PHONE_NUMBER_REGEX.match(detail) is not None:
-            logger.debug("Phone %s", detail)
-            current_site.contact = current_site.contact or []
-            current_site.contact.extend(normalize_phone(detail, contact_type="booking"))
-            # Usually the last detail, so start a new site object
-            current_site = _start_new_site(current_site, sites, entry)
-        elif _DROP_IN_REGEX.match(detail) is not None:
-            logger.debug("Availability = drop in: %s", detail)
-            current_site.availability = (
-                current_site.availability or schema.Availability()
-            )
-            current_site.availability.drop_in = True
-            # Usually the last detail, so start a new site object
-            current_site = _start_new_site(current_site, sites, entry)
-        elif _APPOINTMENTS_REGEX.match(detail) is not None:
-            logger.debug("Availability = appt: %s", detail)
-            current_site.availability = (
-                current_site.availability or schema.Availability()
-            )
-            current_site.availability.appointments = True
-            # Usually the last detail, so start a new site object
-            current_site = _start_new_site(current_site, sites, entry)
-        elif _IGNORE_REGEX.match(detail) is not None:
-            # Ignore these entries entirely, and do not add to sites.
-            # These are usually the Dept of Public Health or CDC website links.
-            logger.debug("Ignoring generic entry: %s", detail)
-            current_site = _make_placeholder_location(entry)
-        elif _IGNORE_NAME_REGEX.match(detail) is not None or current_site.name:
-            # Keep the site, but don't treat this string as the name.
-            logger.debug("Additional note: %s", detail)
-            current_site.notes = current_site.notes or []
-            current_site.notes.append(detail)
+            [city, zip] = city_zip
+            site_builder.add_address_details(city=city, zip=zip)
+        elif _is_phone(detail):
+            site_builder.add_phone(detail)
+        elif _is_drop_in(detail):
+            site_builder.add_availability(drop_in=True)
+        elif _is_appointments(detail):
+            site_builder.add_availability(appointments=True)
+        elif _should_ignore(detail):
+            # Ignore these entries entirely.
+            # These are usually the Dept of Public Health or CDC website links,
+            # or site info that is already captured in a different site.
+            site_builder.fresh_site()
         else:
-            # Everything else gets treated as the site name, if we don't already have one.
-            logger.debug("Site name: %s", detail)
-            current_site.name = current_site.name or detail
-    # Include the last processed site.
-    if (
-        current_site.address
-        or current_site.availability
-        or current_site.name
-        or current_site.contact
-    ):
-        sites.append(current_site)
+            # Either the site name or an extra note.
+            site_builder.add_generic_detail(detail)
 
-    for site in sites:
-        # Add the website and provider name, if we have it.
-        _add_website_and_provider(site, entry)
-        # Generate real IDs, now we have all the site information.
-        _add_id(site)
-    return sites
+    return site_builder.build_sites()
 
 
 _SOURCE_NAME = "al_jefferson"

--- a/vaccine_feed_ingest/runners/al/jefferson/parse.py
+++ b/vaccine_feed_ingest/runners/al/jefferson/parse.py
@@ -314,8 +314,9 @@ def _parse_sites(
 
     Each entry in `sites` is a list of lines of text.
     Each entry is intended to describe a single vaccine site,
-    but there are some exceptions where a single entry will contain
-    multiple addresses for different sites of the same provider.
+    but there are some exceptions where a single entry may contain
+    multiple addresses for different sites of the same provider,
+    or multiple sites may have similar information.
     """
     sites = []
     current_site: ParsedSite = ParsedSite()
@@ -323,8 +324,11 @@ def _parse_sites(
     # Assume a blank line is used to separate different sites
     # for the same provider.
     # This assumption holds for most but not all providers.
-    # When false, it will lead to a single site being reported
-    # for the provider, with all the details joined together by newlines.
+    # When false, it can lead to:
+    # - a single "site" for the provider, with all the details joined together by newlines
+    #   or
+    # - multiple "sites" for the provider that have the same/overlapping information
+    # Normalisation will attempt to handle these.
     for line in lines:
         if line:
             current_site.append(line)


### PR DESCRIPTION
Follow-up to #697, addressing the non-blocking review suggestions by @tmb.

| Key Details |
|-|
State: AL |
Site: Jefferson County |

## Notes
Key changes:
- Refactor the `normalize` loop to hopefully make it more readable and maintainable. This is done by creating a `SiteBuilder` class that maintains state while we are processing a single entry of the parsed output, and pulling out helper functions to check or add each piece of site data.
  - This code now accepts multiple phone numbers, notes, or availability entries for the same site. In practice this doesn't happen in the most recent document, so doesn't affect output.
- Filter out entries starting with "Find a location near you". In the Jefferson County PDF there is a  similar nearby entry for the same provider (healthmart), titled "Make an appointment here", and we don't need both. There are two slightly different URLs for these entries in the PDF, but the parser reports only one and I think that's useful enough. (`https://www.healthmart.com/store-locator.html?query=Birmingham` vs `https://www.healthmart.com/home.html`)

## Data sample

No changes in the output from #697, except for the removal of the spurious entry:
```json
{"id": "al_jefferson:b9b2de124cef054332a6d735b3b0cced", "name": "Find a location near you:", "contact": [{"contact_type": "booking", "website": "https://www.healthmart.com/store-locator.html?query=Birmingham"}], "parent_organization": null, "source": {"source": "al_jefferson", "id": "b9b2de124cef054332a6d735b3b0cced", "fetched_from_uri": "https://www.jcdh.org/SitePages/Misc/PdfViewer?AdminUploadId=1368", "fetched_at": null, "published_at": "2021-05-25T00:00:00-05:00", "data": {"page": 3, "provider": 12, "link": "https://www.healthmart.com/store-locator.html?query=Birmingham", "details": ["Find a location near you:"], "fetched_from_uri": "https://www.jcdh.org/SitePages/Misc/PdfViewer?AdminUploadId=1368", "published_at": "2021-05-25T00:00:00-05:00"}}}
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
