### PR TITLE
Fixes #693: fetch ar/state_health_units

### DIFF
--- a/vaccine_feed_ingest/runners/ar/state_health_units/fetch.sh
+++ b/vaccine_feed_ingest/runners/ar/state_health_units/fetch.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+output_dir=""
+
+if [ -n "${1}" ]; then
+    output_dir="${1}"
+else
+    echo "Must pass an output_dir as first argument"
+fi
+
+(cd "$output_dir" && curl --silent https://www.healthy.arkansas.gov/local-health-units -o data.html)


### PR DESCRIPTION
# fetch state_health_units for AR

| Key Details |
|-|
| Resolves #693  |
State: ar |
Site: state_health_units |

## Notes

Straightforward fetcher script. Verified by examining the output of this command:

```sh
curl --silent https://www.healthy.arkansas.gov/local-health-units -o data.html
```

## Data sample

The fetched HTML has a `<table>` with _rows_ of data, where each **row** has  information about a "health unit" that administers vaccines:

```html
<tr>
  <td><a href="/health-units/detail/yell-county-health-unit-dardanelle">Yell County Health Unit - Dardanelle</a></td>
  <td>Dardanelle</td>
  <td>479-229-3509</td>
  <td>Monday, Wednesday – Friday 8am – 4:30pm and Tuesday’s 9:30am to 6pm</td>
</tr>
```

## Before Opening a PR
- [x] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [x] I ran auto-formatting: `poetry run tox -e lint-fix`
