### PR TITLE
chore: improve sentry usage

### DIFF
--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -252,15 +252,19 @@ def cli():
     """Run vaccine-feed-ingest commands"""
     dotenv.load_dotenv()
 
+    sentry_enabled = os.environ.get("SENTRY_ENABLE", False)
     sentry_path = os.environ.get("SENTRY_DSN")
-    if sentry_path:
-        sentry_sdk.init(
-            dsn=sentry_path,
-            # 1.0 would capture 100% of transactions for performance monitoring.
-            traces_sample_rate=0.0,
-        )
+    if sentry_enabled:
+        if sentry_path:
+            sentry_sdk.init(
+                dsn=sentry_path,
+                # 1.0 would capture 100% of transactions for performance monitoring.
+                traces_sample_rate=0.0,
+            )
+        else:
+            logger.error("Sentry enabled but no config provided. Disabling Sentry.")
     else:
-        logger.info("Sentry disabled (no config provided).")
+        logger.info("Sentry disabled by environment variable.")
 
 
 @cli.command()

--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -13,7 +13,11 @@ import dotenv
 import pathy
 import sentry_sdk
 
+from vaccine_feed_ingest.utils.log import getLogger
+
 from .stages import caching, common, ingest, load, site
+
+logger = getLogger(__file__)
 
 # Collect locations that are within .6 degrees = 66.6 km = 41 mi
 CANDIDATE_DEGREES_DISTANCE = 0.6
@@ -256,7 +260,7 @@ def cli():
             traces_sample_rate=0.0,
         )
     else:
-        print("Sentry disabled (no config provided).")
+        logger.info("Sentry disabled (no config provided).")
 
 
 @cli.command()

--- a/vaccine_feed_ingest/stages/ingest.py
+++ b/vaccine_feed_ingest/stages/ingest.py
@@ -9,6 +9,7 @@ from typing import Collection, Optional
 
 import orjson
 import pydantic
+from sentry_sdk import set_tag
 from vaccine_feed_ingest_schema import location
 
 from vaccine_feed_ingest.utils.log import getLogger
@@ -30,6 +31,9 @@ def run_fetch(
     dry_run: bool = False,
     fail_on_runner_error: bool = True,
 ) -> bool:
+    set_tag("vts.runner", f"{site_dir.parent.name}/{site_dir.name}")
+    set_tag("vts.stage", "fetch")
+
     fetch_path, yml_path = site.resolve_executable(site_dir, PipelineStage.FETCH)
     if not fetch_path:
         log_msg = (
@@ -62,10 +66,10 @@ def run_fetch(
             if fail_on_runner_error:
                 raise e
             logger.error(
-                "Subprocess %s/%s errored, stage will be skipped: %s",
+                "Subprocess %s/%s errored, stage will be skipped",
                 site_dir.parent.name,
                 site_dir.name,
-                e,
+                exc_info=True,
             )
             return False
 
@@ -100,6 +104,9 @@ def run_parse(
     dry_run: bool = False,
     fail_on_runner_error: bool = True,
 ) -> bool:
+    set_tag("vts.runner", f"{site_dir.parent.name}/{site_dir.name}")
+    set_tag("vts.stage", "parse")
+
     parse_path, yml_path = site.resolve_executable(site_dir, PipelineStage.PARSE)
     if not parse_path:
         log_msg = (
@@ -158,10 +165,10 @@ def run_parse(
             if fail_on_runner_error:
                 raise e
             logger.error(
-                "Subprocess %s/%s errored, stage will be skipped: %s",
+                "Subprocess %s/%s errored, stage will be skipped",
                 site_dir.parent.name,
                 site_dir.name,
-                e,
+                exc_info=True,
             )
             return False
 
@@ -206,6 +213,9 @@ def run_normalize(
     dry_run: bool = False,
     fail_on_runner_error: bool = True,
 ) -> bool:
+    set_tag("vts.runner", f"{site_dir.parent.name}/{site_dir.name}")
+    set_tag("vts.stage", "normalize")
+
     normalize_path, yml_path = site.resolve_executable(
         site_dir, PipelineStage.NORMALIZE
     )
@@ -273,10 +283,10 @@ def run_normalize(
             if fail_on_runner_error:
                 raise e
             logger.error(
-                "Subprocess %s/%s errored, stage will be skipped: %s",
+                "Subprocess %s/%s errored, stage will be skipped",
                 site_dir.parent.name,
                 site_dir.name,
-                e,
+                exc_info=True,
             )
             return False
 
@@ -325,6 +335,9 @@ def run_enrich(
     placekey_apikey: Optional[str] = None,
     dry_run: bool = False,
 ) -> bool:
+    set_tag("vts.runner", f"{site_dir.parent.name}/{site_dir.name}")
+    set_tag("vts.stage", "enrich")
+
     normalize_run_dir = outputs.find_latest_run_dir(
         output_dir, site_dir.parent.name, site_dir.name, PipelineStage.NORMALIZE
     )

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -10,6 +10,7 @@ import rtree
 import shapely.geometry
 import urllib3
 import us
+from sentry_sdk import set_tag
 from vaccine_feed_ingest_schema import load, location
 
 from vaccine_feed_ingest.utils.log import getLogger
@@ -117,6 +118,9 @@ def run_load_to_vial(
     import_batch_size: int = 500,
 ) -> Optional[List[load.ImportSourceLocation]]:
     """Load source to vial source locations"""
+    set_tag("vts.runner", f"{site_dir.parent.name}/{site_dir.name}")
+    set_tag("vts.stage", "load-to-vial")
+
     ennrich_run_dir = outputs.find_latest_run_dir(
         output_dir, site_dir.parent.name, site_dir.name, PipelineStage.ENRICH
     )


### PR DESCRIPTION
Address PR comments from #705, and add sentry tags.

* A new environment variable, `SENTRY_ENABLE`, must be set in order for Sentry to be configured.
* Sentry errors from runners now have tags `vts.stage` (with the stage) and `vts.runner` (with the `state/site` name).