### PR TITLE
fix: do not include exception in log

### DIFF
--- a/vaccine_feed_ingest/stages/ingest.py
+++ b/vaccine_feed_ingest/stages/ingest.py
@@ -66,10 +66,9 @@ def run_fetch(
             if fail_on_runner_error:
                 raise e
             logger.error(
-                "Subprocess %s/%s errored, stage will be skipped",
+                "Subprocess %s/%s errored on fetch, stage will be skipped",
                 site_dir.parent.name,
                 site_dir.name,
-                exc_info=True,
             )
             return False
 
@@ -165,10 +164,9 @@ def run_parse(
             if fail_on_runner_error:
                 raise e
             logger.error(
-                "Subprocess %s/%s errored, stage will be skipped",
+                "Subprocess %s/%s errored on parse, stage will be skipped",
                 site_dir.parent.name,
                 site_dir.name,
-                exc_info=True,
             )
             return False
 
@@ -283,10 +281,9 @@ def run_normalize(
             if fail_on_runner_error:
                 raise e
             logger.error(
-                "Subprocess %s/%s errored, stage will be skipped",
+                "Subprocess %s/%s errored on normalize, stage will be skipped",
                 site_dir.parent.name,
                 site_dir.name,
-                exc_info=True,
             )
             return False
 


### PR DESCRIPTION
In #706 I set `exc_info=True` on error logs in `ingest`. This had the effect of Sentry rolling up errors from separate runners failing as the same error.

There is likely a better way to fix this, but in the meantime roll back that change and add additional text to the log message to ensure the errors are separated.