### PR TITLE
Update US state normalization in us/giscorps_vaccine_providers

### DIFF
--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -214,6 +214,7 @@ def normalize_state_name(name: str) -> str:
 
     name = name.strip()
     name = name.replace(".", "")
+    name = name.replace("'", "")
 
     # capitalize the first letter of each word in cases where a state name is provided
     spl = name.split(" ")
@@ -250,6 +251,8 @@ def apply_address_fixups(address: OrderedDict[str, str]) -> OrderedDict[str, str
             state = "Michigan"
         elif state == "SR":
             raise CustomBailError()
+        elif state == "GL":
+            state = "FL"
 
         if state in ["Bay Arkansas", "Palestine Arkansas"]:
             spl = state.split(" ")

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -7,6 +7,7 @@ import pathlib
 import sys
 from typing import List, Optional, OrderedDict
 
+import us
 import usaddress
 from opening_hours import OpeningHours
 from vaccine_feed_ingest_schema import location as schema
@@ -211,65 +212,6 @@ def normalize_state_name(name: str) -> str:
     if name is None:
         return name
 
-    us_state_abbrev = {
-        "Alabama": "AL",
-        "Alaska": "AK",
-        "American Samoa": "AS",
-        "Arizona": "AZ",
-        "Arkansas": "AR",
-        "California": "CA",
-        "Colorado": "CO",
-        "Connecticut": "CT",
-        "Delaware": "DE",
-        "District of Columbia": "DC",
-        "Florida": "FL",
-        "Georgia": "GA",
-        "Guam": "GU",
-        "Hawaii": "HI",
-        "Idaho": "ID",
-        "Illinois": "IL",
-        "Indiana": "IN",
-        "Iowa": "IA",
-        "Kansas": "KS",
-        "Kentucky": "KY",
-        "Louisiana": "LA",
-        "Maine": "ME",
-        "Maryland": "MD",
-        "Massachusetts": "MA",
-        "Michigan": "MI",
-        "Minnesota": "MN",
-        "Mississippi": "MS",
-        "Missouri": "MO",
-        "Montana": "MT",
-        "Nebraska": "NE",
-        "Nevada": "NV",
-        "New Hampshire": "NH",
-        "New Jersey": "NJ",
-        "New Mexico": "NM",
-        "New York": "NY",
-        "North Carolina": "NC",
-        "North Dakota": "ND",
-        "Northern Mariana Islands": "MP",
-        "Ohio": "OH",
-        "Oklahoma": "OK",
-        "Oregon": "OR",
-        "Pennsylvania": "PA",
-        "Puerto Rico": "PR",
-        "Rhode Island": "RI",
-        "South Carolina": "SC",
-        "South Dakota": "SD",
-        "Tennessee": "TN",
-        "Texas": "TX",
-        "Utah": "UT",
-        "Vermont": "VT",
-        "Virgin Islands": "VI",
-        "Virginia": "VA",
-        "Washington": "WA",
-        "West Virginia": "WV",
-        "Wisconsin": "WI",
-        "Wyoming": "WY",
-    }
-
     name = name.strip()
     name = name.replace(".", "")
 
@@ -280,10 +222,10 @@ def normalize_state_name(name: str) -> str:
     else:
         name = name.lower().capitalize()
 
-    if name in us_state_abbrev:
-        return us_state_abbrev[name]
-
-    return name.upper()
+    try:
+        return us.states.lookup(name).abbr
+    except Exception:
+        return name.upper()
 
 
 def apply_address_fixups(address: OrderedDict[str, str]) -> OrderedDict[str, str]:

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -223,9 +223,10 @@ def normalize_state_name(name: str) -> str:
     else:
         name = name.lower().capitalize()
 
-    try:
-        return us.states.lookup(name).abbr
-    except Exception:
+    lookup = us.states.lookup(name)
+    if lookup:
+        return lookup.abbr
+    else:
         return name.upper()
 
 


### PR DESCRIPTION
# us/giscorps_vaccine_providers
| Key Details |
|-|
| Resolves  N/A |
State: us |
Site: giscorps_vaccine_providers |

## Notes
streamlines normalizing of US state names using the `us` library as suggested by @bryanculbertson in #677.

Also handles a couple additional edge cases that were causing this process to fail.


## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
