### PR TITLE
fetch and parse sc/dhec_arcgis

### DIFF
--- a/vaccine_feed_ingest/runners/sc/dhec_arcgis/fetch.yml
+++ b/vaccine_feed_ingest/runners/sc/dhec_arcgis/fetch.yml
@@ -1,0 +1,6 @@
+---
+state: sc
+arcgis:
+- id: 4edb42495ae545d58d378e3127c1afeb
+  layer_names:
+  - vaccine_locations_agol

--- a/vaccine_feed_ingest/runners/sc/dhec_arcgis/parse.yml
+++ b/vaccine_feed_ingest/runners/sc/dhec_arcgis/parse.yml
@@ -1,0 +1,4 @@
+---
+state: sc
+site: arcgis
+parser: arcgis_features


### PR DESCRIPTION
# fetch and parse sc/dhec_arcgis
| Key Details |
|-|
| Resolves #723 resolves #743 resolves #732 resolves #750 |
State: sc |
Site: dhec_arcgis |

## Notes
simple arcgis fetch and parse using the shared runner

not sure what happened with vaccinebot and the duplicate issues tho

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```json
{"attributes": {"Activated1": "Yes", "Appointments": "No", "Contact": null, "GlobalID": "b456ea0b-db46-42f4-9bbe-3df1a38e4fa8", "Loc_ID": 845, "OBJECTID": 1, "Phone_Sec": null, "Region": "Lowcountry", "SiteAddress": "137 gateway drive", "SiteAddressDetail": null, "SiteCity": "Ladson", "SitePhone": "", "SiteState": "SC", "SiteZip": "29456", "URL": null, "V_Manufacturer": null, "layer_id": 0, "loc_name": "Carolina Cataract and Vision Center", "loc_type1": "Medical practice \u2013 other specialty", "ref_ID": 954, "service_item_id": "4edb42495ae545d58d378e3127c1afeb", "vfc_text": "SCA918009", "vtrcks_ID": 40208317}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -80.09152585378803, "y": 32.997858505756824}}
{"attributes": {"Activated1": "Yes", "Appointments": "No", "Contact": null, "GlobalID": "220d6067-6ceb-4655-93ef-b5ed05e84c49", "Loc_ID": 813, "OBJECTID": 2, "Phone_Sec": null, "Region": "Midlands", "SiteAddress": "105 E Hugh St", "SiteAddressDetail": null, "SiteCity": "North Augusta", "SitePhone": "", "SiteState": "SC", "SiteZip": "29841", "URL": null, "V_Manufacturer": null, "layer_id": 0, "loc_name": "Center for Primary Care, PC", "loc_type1": "Medical practice \u2013 family medicine", "ref_ID": 955, "service_item_id": "4edb42495ae545d58d378e3127c1afeb", "vfc_text": "SCA502005", "vtrcks_ID": 40117843}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -81.95652331218946, "y": 33.51771994180649}}
{"attributes": {"Activated1": "Yes", "Appointments": "No", "Contact": null, "GlobalID": "6ef35196-c3f4-4464-a572-17f00f83c669", "Loc_ID": 782, "OBJECTID": 3, "Phone_Sec": null, "Region": "Upstate", "SiteAddress": "125 Lila Doyle Drive", "SiteAddressDetail": null, "SiteCity": "Seneca", "SitePhone": "", "SiteState": "SC", "SiteZip": "29678", "URL": null, "V_Manufacturer": null, "layer_id": 0, "loc_name": "Seneca Health and Wellness Center/Cigna Onsite Health, LLC", "loc_type1": "Health center \u2013 occupational", "ref_ID": 956, "service_item_id": "4edb42495ae545d58d378e3127c1afeb", "vfc_text": "SCA937006", "vtrcks_ID": 40226365}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -82.98411190682685, "y": 34.69404697221887}}
```

## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
