### PR TITLE
fetch al/cahaba

### DIFF
--- a/vaccine_feed_ingest/runners/al/cahaba/fetch.sh
+++ b/vaccine_feed_ingest/runners/al/cahaba/fetch.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+output_dir=""
+
+if [ -n "${1}" ]; then
+    output_dir="${1}"
+else
+    echo "Must pass an output_dir as first argument"
+fi
+
+curl "https://www.cahabamedicalcare.com/covid19" \
+    -o "${output_dir}/al_cahaba.html"


### PR DESCRIPTION
# fetch al/cahaba

| Key Details |
|-|
| Resolves #721  |
State: al |
Site: cahaba |

## Notes
simple download of an HTML file.

vaccinebot may have messed up the issues

## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->

Data is sorta buried in the HTML

## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
