### PR TITLE
Miscellaneous changes to load GetMyVax

### DIFF
--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -15,15 +15,13 @@ import sentry_sdk
 
 from vaccine_feed_ingest.utils.log import getLogger
 
+from . import vial
 from .stages import caching, common, ingest, load, site
 
 logger = getLogger(__file__)
 
 # Collect locations that are within .6 degrees = 66.6 km = 41 mi
 CANDIDATE_DEGREES_DISTANCE = 0.6
-
-# Default import batch size to vial
-IMPORT_BATCH_SIZE = 500
 
 
 def _generate_run_timestamp() -> str:
@@ -243,7 +241,7 @@ def _import_batch_size_option() -> Callable:
         "--import-batch-size",
         "import_batch_size",
         type=int,
-        default=lambda: os.environ.get("IMPORT_BATCH_SIZE", IMPORT_BATCH_SIZE),
+        default=lambda: os.environ.get("IMPORT_BATCH_SIZE", vial.IMPORT_BATCH_SIZE),
     )
 
 

--- a/vaccine_feed_ingest/runners/us/getmyvax_org/normalize.py
+++ b/vaccine_feed_ingest/runners/us/getmyvax_org/normalize.py
@@ -406,7 +406,8 @@ for in_filepath in input_dir.iterdir():
     timestamp = datetime.datetime.now()
 
     with in_filepath.open("rb") as in_file:
-        out_filepath = output_dir / f"{in_filepath.stem}.normalized.ndjson"
+        filepath_stem = in_filepath.name[: -len(".parsed.ndjson")]
+        out_filepath = output_dir / f"{filepath_stem}.normalized.ndjson"
         with out_filepath.open("wb") as out_file:
             for line in in_file:
                 out_loc_ndjson = process_line(line, timestamp)

--- a/vaccine_feed_ingest/runners/us/getmyvax_org/normalize.py
+++ b/vaccine_feed_ingest/runners/us/getmyvax_org/normalize.py
@@ -175,6 +175,7 @@ def process_line(line: bytes, timestamp: datetime.datetime) -> bytes:
 
 def _get_address(loc: GMVLocation) -> Optional[location.Address]:
     if not loc.address_lines and not loc.city and not loc.state and not loc.postal_code:
+        logger.info("No address for location %s (%s)", loc.id, loc.name)
         return None
 
     street1 = None
@@ -190,7 +191,7 @@ def _get_address(loc: GMVLocation) -> Optional[location.Address]:
         if state := us.states.lookup(loc.state):
             state_abbr = state.abbr
         else:
-            logger.warning("Invalid state %s", loc.state)
+            logger.warning("Invalid state %s for %s (%s)", loc.state, loc.id, loc.name)
 
     postal_code = None
     # Handle invalid postal codes that are less than 5 digits
@@ -198,7 +199,9 @@ def _get_address(loc: GMVLocation) -> Optional[location.Address]:
         if len(loc.postal_code) >= 5:
             postal_code = loc.postal_code
         else:
-            logger.warning("Invalid postal code %s", loc.postal_code)
+            logger.warning(
+                "Invalid postal code %s for %s (%s)", loc.postal_code, loc.id, loc.name
+            )
 
     return location.Address(
         street1=street1,
@@ -211,6 +214,7 @@ def _get_address(loc: GMVLocation) -> Optional[location.Address]:
 
 def _get_lat_lng(loc: GMVLocation) -> Optional[location.LatLng]:
     if not loc.position:
+        logger.debug("No lat-lng for location %s (%s)", loc.id, loc.name)
         return None
 
     # Skip positions that are missing a value

--- a/vaccine_feed_ingest/runners/us/getmyvax_org/parse.py
+++ b/vaccine_feed_ingest/runners/us/getmyvax_org/parse.py
@@ -19,6 +19,10 @@ def _strip_unused_larged_fields(loc: dict) -> None:
     if loc.get("availability") and "slots" in loc["availability"]:
         del loc["availability"]["slots"]
 
+    # Remove appointment availability capacity
+    if loc.get("availability") and "capacity" in loc["availability"]:
+        del loc["availability"]["capacity"]
+
 
 output_dir = pathlib.Path(sys.argv[1]) if len(sys.argv) >= 2 else None
 if output_dir is None:

--- a/vaccine_feed_ingest/stages/enrichment.py
+++ b/vaccine_feed_ingest/stages/enrichment.py
@@ -21,6 +21,7 @@ logger = getLogger(__file__)
 
 
 PROVIDER_TAG = "_tag_provider"
+GEOCODIO_BATCH_SIZE = 1_000
 
 
 def enrich_locations(
@@ -298,7 +299,7 @@ def _bulk_geocode(
     if not records:
         return
 
-    for chunked_records in misc.dict_batch(records, 5000):
+    for chunked_records in misc.dict_batch(records, GEOCODIO_BATCH_SIZE):
         logger.info("attempting to geocode %d locations", len(chunked_records))
         places = geocodio_api.batch_geocode(chunked_records)
 

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -115,7 +115,7 @@ def run_load_to_vial(
     match_ids: Optional[Dict[str, str]] = None,
     create_ids: Optional[Collection[str]] = None,
     candidate_distance: float = 0.6,
-    import_batch_size: int = 500,
+    import_batch_size: int = vial.IMPORT_BATCH_SIZE,
 ) -> Optional[List[load.ImportSourceLocation]]:
     """Load source to vial source locations"""
     set_tag("vts.runner", f"{site_dir.parent.name}/{site_dir.name}")

--- a/vaccine_feed_ingest/vial.py
+++ b/vaccine_feed_ingest/vial.py
@@ -19,6 +19,9 @@ from .utils import misc
 
 logger = getLogger(__file__)
 
+# Default import batch size to vial
+IMPORT_BATCH_SIZE = 100
+
 
 @contextlib.contextmanager
 def vial_client(
@@ -71,7 +74,7 @@ def import_source_locations(
     vial_http: urllib3.connectionpool.ConnectionPool,
     import_run_id: str,
     import_locations: Iterable[load.ImportSourceLocation],
-    import_batch_size: int = 500,
+    import_batch_size: int = IMPORT_BATCH_SIZE,
 ) -> None:
     """Import source locations"""
     path_and_query = f"/api/importSourceLocations?import_run_id={import_run_id}"


### PR DESCRIPTION
1. Fix naming of normalized output to be `{state}.normalized.ndjson` instead of `{state}.parsed.normalized.ndjson`
2. Add logging for more failure modes so we can see what is happening.
3. Strip out unused real-time appointment capacity. It will make the json entries smaller and faster to load.
4. Send batched of `1000` to geocodio.
5. Import batched of `100` to VIAL.