### PR TITLE
Option to limit number of records to import for a site

### DIFF
--- a/vaccine_feed_ingest/cli.py
+++ b/vaccine_feed_ingest/cli.py
@@ -245,6 +245,14 @@ def _import_batch_size_option() -> Callable:
     )
 
 
+def _import_limit_option() -> Callable:
+    return click.option(
+        "--import-limit",
+        "import_limit",
+        type=int,
+    )
+
+
 @click.group()
 def cli():
     """Run vaccine-feed-ingest commands"""
@@ -479,6 +487,7 @@ def enrich(
 @_create_ids_option()
 @_candidate_distance_option()
 @_import_batch_size_option()
+@_import_limit_option()
 def load_to_vial(
     sites: Optional[Sequence[str]],
     exclude_sites: Optional[Collection[str]],
@@ -495,6 +504,7 @@ def load_to_vial(
     create_ids: Optional[Collection[str]],
     candidate_distance: float,
     import_batch_size: int,
+    import_limit: Optional[int],
 ) -> None:
     """Load specified sites to vial server."""
     site_dirs = site.get_site_dirs(state, sites, exclude_sites)
@@ -520,6 +530,7 @@ def load_to_vial(
         create_ids=create_ids,
         candidate_distance=candidate_distance,
         import_batch_size=import_batch_size,
+        import_limit=import_limit,
     )
 
 
@@ -544,6 +555,7 @@ def load_to_vial(
 @_create_ids_option()
 @_candidate_distance_option()
 @_import_batch_size_option()
+@_import_limit_option()
 @_fail_on_error_option()
 def pipeline(
     sites: Optional[Sequence[str]],
@@ -566,6 +578,7 @@ def pipeline(
     create_ids: Optional[Collection[str]],
     candidate_distance: float,
     import_batch_size: int,
+    import_limit: Optional[int],
     fail_on_runner_error: bool,
 ) -> None:
     """Run all stages in succession for specified sites."""
@@ -645,6 +658,7 @@ def pipeline(
             create_ids=create_ids,
             candidate_distance=candidate_distance,
             import_batch_size=import_batch_size,
+            import_limit=import_limit,
         )
 
 

--- a/vaccine_feed_ingest/stages/load.py
+++ b/vaccine_feed_ingest/stages/load.py
@@ -44,6 +44,7 @@ def load_sites_to_vial(
     create_ids: Optional[Collection[str]],
     candidate_distance: float,
     import_batch_size: int,
+    import_limit: Optional[int],
 ) -> None:
     """Load list of sites to vial"""
     with vial.vial_client(vial_server, vial_apikey) as vial_http:
@@ -85,6 +86,7 @@ def load_sites_to_vial(
                 create_ids=create_ids,
                 candidate_distance=candidate_distance,
                 import_batch_size=import_batch_size,
+                import_limit=import_limit,
             )
 
             # If data was loaded then refresh existing locations
@@ -116,6 +118,7 @@ def run_load_to_vial(
     create_ids: Optional[Collection[str]] = None,
     candidate_distance: float = 0.6,
     import_batch_size: int = vial.IMPORT_BATCH_SIZE,
+    import_limit: Optional[int] = None,
 ) -> Optional[List[load.ImportSourceLocation]]:
     """Load source to vial source locations"""
     set_tag("vts.runner", f"{site_dir.parent.name}/{site_dir.name}")
@@ -229,6 +232,12 @@ def run_load_to_vial(
                         num_new_locations += 1
 
                 import_locations.append(import_location)
+
+                if import_limit and num_imported_locations >= import_limit:
+                    logger.info(
+                        "Reached import limit of %d and starting load", import_limit
+                    )
+                    break
 
         if not import_locations:
             logger.warning(

--- a/vaccine_feed_ingest/vial.py
+++ b/vaccine_feed_ingest/vial.py
@@ -89,12 +89,16 @@ def import_source_locations(
             ]
         )
 
-        rsp = vial_http.request(
-            "POST",
-            path_and_query,
-            headers={**vial_http.headers, "Content-Type": "application/x-ndjson"},
-            body=encoded_ndjson,
-        )
+        try:
+            rsp = vial_http.request(
+                "POST",
+                path_and_query,
+                headers={**vial_http.headers, "Content-Type": "application/x-ndjson"},
+                body=encoded_ndjson,
+            )
+        except urllib3.exceptions.ReadTimeoutError:
+            logger.error("Timeout while importing: %s", encoded_ndjson[:100])
+            raise
 
         if rsp.status != 200:
             raise HTTPError(


### PR DESCRIPTION
Add an option to limit the number of records to import with `--import-limit`

This is useful for testing import without needing to match all records first.