### PR TITLE
chore: overbroad exception rescue on vial post

### DIFF
--- a/vaccine_feed_ingest/vial.py
+++ b/vaccine_feed_ingest/vial.py
@@ -96,8 +96,13 @@ def import_source_locations(
                 headers={**vial_http.headers, "Content-Type": "application/x-ndjson"},
                 body=encoded_ndjson,
             )
-        except urllib3.exceptions.ReadTimeoutError:
-            logger.error("Timeout while importing: %s", encoded_ndjson[:100])
+        except Exception as e:
+            logger.error(
+                "Error while importing locations: %s (...) %s: %s",
+                encoded_ndjson[:100],
+                encoded_ndjson[-100:],
+                e,
+            )
             raise
 
         if rsp.status != 200:


### PR DESCRIPTION
We continue to have timeouts. Rescue all potential exceptions and log them aggressively to attempt to debug.