### PR TITLE
Fix akcliniclist

### DIFF
--- a/vaccine_feed_ingest/runners/ak/clinic_list/normalize.py
+++ b/vaccine_feed_ingest/runners/ak/clinic_list/normalize.py
@@ -38,6 +38,7 @@ def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:
 def _get_availability(site: dict) -> Optional[schema.Availability]:
     if site["attributes"]["flu_walkins"] == "no_please_make_an_appointment":
         return schema.Availability(drop_in=False)
+    return None
 
 
 def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:

--- a/vaccine_feed_ingest/runners/ak/clinic_list/normalize.py
+++ b/vaccine_feed_ingest/runners/ak/clinic_list/normalize.py
@@ -26,8 +26,7 @@ def _get_id(site: dict) -> str:
 def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:
     ret = []
     if phone := site["attributes"]["phone"]:
-        for phone in normalize_phone(phone):
-            ret.append(schema.Contact(phone=phone))
+        ret.extend(normalize_phone(phone))
     if email := site["attributes"]["publicEmail"]:
         ret.append(schema.Contact(email=email))
     if website := site["attributes"]["publicWebsite"]:


### PR DESCRIPTION
Resolves normalizer errors  in ak/clinic_list.

Issue was an assumption that the `normalize_phone` method returned a list of strings, not `Contact` objects 


## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
