### PR TITLE
Giscorps contacts provider fixes

### DIFF
--- a/vaccine_feed_ingest/runners/us/vaccinespotter_org/normalize.py
+++ b/vaccine_feed_ingest/runners/us/vaccinespotter_org/normalize.py
@@ -35,6 +35,15 @@ def _get_address(site: dict) -> Optional[schema.Address]:
     return None
 
 
+def _get_contact(site) -> Optional[schema.Contact]:
+
+    if url := site.get("url"):
+        return [
+            schema.Contact(contact_type=None, phone=None, website=url),
+        ]
+    return None
+
+
 def _get_lat_lng(geometry: dict, id: str) -> Optional[schema.LatLng]:
     try:
         lat_lng = schema.LatLng(

--- a/vaccine_feed_ingest/runners/us/vaccinespotter_org/normalize.py
+++ b/vaccine_feed_ingest/runners/us/vaccinespotter_org/normalize.py
@@ -72,9 +72,9 @@ def normalize(site_blob: dict, timestamp: str) -> dict:
     site = site_blob["properties"]
 
     links = [schema.Link(authority="vaccinespotter_org", id=site["id"])]
-
-    parsed_provider_link = provider_id_from_name(
-        site["provider_brand_name"]  # or use site["name"]?
+    brandname = site["provider_brand_name"]
+    parsed_provider_link = (
+        provider_id_from_name(brandname) if brandname else None  # or use site["name"]?
     )
     if parsed_provider_link is not None:
         links.append(
@@ -88,9 +88,7 @@ def normalize(site_blob: dict, timestamp: str) -> dict:
         name=site["name"],
         address=_get_address(site),
         location=_get_lat_lng(site_blob["geometry"], site["id"]),
-        contact=[
-            schema.Contact(contact_type=None, phone=None, website=site["url"]),
-        ],
+        contact=_get_contact(site),
         languages=None,
         opening_dates=None,
         opening_hours=None,


### PR DESCRIPTION
Fixes handling of `None` values in two places: 
- handling of contacts (specifically for parsing the `url` key)
- handling of `None` in `provider_brand_name` which was causing the util function to fail.


A better fix may be to update `provider_id_from_name` in the normalizer utils to accept `None` as a value and return `None`, but this seemed like it might affect a lot more normalizers and wasn't attempted 

## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
