### PR TITLE
Normalize all the arcgis sources for SC

### DIFF
--- a/vaccine_feed_ingest/runners/sc/dab_arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/sc/dab_arcgis/normalize.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python
+
+import datetime
+import json
+import os
+import pathlib
+import re
+import sys
+from typing import List, Optional
+
+from pydantic import ValidationError
+from vaccine_feed_ingest_schema import location as schema
+
+from vaccine_feed_ingest.utils.log import getLogger
+from vaccine_feed_ingest.utils.normalize import normalize_phone, normalize_zip
+
+logger = getLogger(__file__)
+
+output_dir = pathlib.Path(sys.argv[1])
+input_dir = pathlib.Path(sys.argv[2])
+
+json_filepaths = input_dir.glob("*.ndjson")
+
+parsed_at_timestamp = datetime.datetime.utcnow().isoformat()
+
+
+def _get_id(site: dict) -> str:
+    data_id = site["attributes"]["GlobalID"]
+
+    # Could parse these from directory traversal, but do not for now to avoid
+    # accidental mutation.
+    site_name = "dab_arcgis"
+    runner = "sc"
+
+    # Could parse these from the input file name, but do not for now to avoid
+    # accidental mutation.
+    arcgis = "d5c82a2ca66440459d96d237390a852d"
+    layer = 0
+
+    return f"{runner}_{site_name}:{arcgis}_{layer}_{data_id}"
+
+
+# This currently tosses any address if it doesn't have a street address or zip because
+# the schema doesn't allow optionals for those
+def _get_address(site: dict) -> Optional[schema.Address]:
+    zipc = normalize_zip(site["attributes"]["SiteZip"])
+
+    return schema.Address(
+        street1=site["attributes"]["SiteAddress"],
+        street2=site["attributes"]["SiteAddressDetail"],
+        city=site["attributes"]["SiteCity"],
+        state="SC",
+        zip=zipc,
+    )
+
+
+def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:
+    contacts = []
+    if site["attributes"]["SitePhone"]:
+        for phone in normalize_phone(site["attributes"]["SitePhone"]):
+            contacts.append(phone)
+
+    # Contacts seems to be a free text field where people usually enter emails but also sometimes
+    # other stuff like numbers, hours of operation, etc
+    if site["attributes"]["Contact"]:
+        if "@" in site["attributes"]["Contact"]:
+            contacts.append(
+                schema.Contact(
+                    contact_type="general", email=site["attributes"]["Contact"]
+                )
+            )
+        else:
+            contacts.append(
+                schema.Contact(
+                    contact_type="general", other=site["attributes"]["Contact"]
+                )
+            )
+
+    url = site["attributes"]["URL"]
+    if url:
+        url = url if "http" in url else "https://" + url
+        URL_RE = re.compile(
+            r"^((https?):\/\/)(www.)?[a-z0-9]+\.[a-z]+(\/?[a-zA-Z0-9#]+\/?)*$"
+        )
+        valid = URL_RE.match(url)
+        if valid:
+            contacts.append(schema.Contact(contact_type="general", website=url))
+
+    if len(contacts) > 0:
+        return contacts
+
+    return None
+
+
+# Using "Appointments" field though unclear whether this should be interpreted as
+# "An appointment is required" or "An appointment is available"
+def _get_activated(site: dict) -> bool:
+    # if site["attributes"]["Activated1"] == "No":
+    #     return False
+    # else:
+    #     return True
+    return None
+
+
+def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
+    if site["attributes"]["V_Manufacturer"]:
+        vaccines_field = map(
+            lambda str: str.strip(),
+            site["attributes"]["V_Manufacturer"].lower().split(","),
+        )
+
+        potentials = {
+            "pzr": schema.Vaccine(vaccine="pfizer_biontech"),
+            "pfr": schema.Vaccine(vaccine="pfizer_biontech"),
+            "pfizer": schema.Vaccine(vaccine="pfizer_biontech"),
+            "mod": schema.Vaccine(vaccine="moderna"),
+            "moderna": schema.Vaccine(vaccine="moderna"),
+            "jj": schema.Vaccine(vaccine="johnson_johnson_janssen"),
+            "jjj": schema.Vaccine(vaccine="johnson_johnson_janssen"),
+        }
+
+        inventory = []
+
+        for vf in vaccines_field:
+            try:
+                inventory.append(potentials[vf])
+            except KeyError as e:
+                logger.error("Unexpected vaccine type: %s", e)
+
+        if len(inventory) > 0:
+            return inventory
+
+    return None
+
+
+def _get_normalized_location(
+    site: dict, timestamp: str
+) -> Optional[schema.NormalizedLocation]:
+    if site["attributes"] is None:
+        logger.error(
+            "Cannot normalize site data without an 'attributes' field: %s", site
+        )
+        return None
+    name = site["attributes"]["loc_name"]
+    if name is None:
+        logger.error(
+            "Cannot normalize site data without an 'attributes.loc_name' field: %s",
+            site,
+        )
+        return None
+    if len(name) > 256:
+        logger.error("Site name must have 256 characters or fewer; ignoring %s", name)
+        return None
+
+    # Contact parsing for this site is a little flaky. Ensure that a bug for
+    # a single entry does not halt overall scraping.
+    try:
+        contacts = _get_contacts(site)
+    except ValidationError:
+        logger.warning(
+            "Errored while trying to parse contact from %s, %s, or %s",
+            site["attributes"]["SitePhone"],
+            site["attributes"]["Contact"],
+            site["attributes"]["URL"],
+        )
+        contacts = None
+
+    return schema.NormalizedLocation(
+        id=_get_id(site),
+        name=name,
+        address=_get_address(site),
+        location=schema.LatLng(
+            latitude=site["geometry"]["y"],
+            longitude=site["geometry"]["x"],
+        ),
+        contact=contacts,
+        languages=None,
+        opening_dates=None,
+        opening_hours=None,
+        # There is an "Appointments" field in the data though it is unclear whether this should be interpreted as
+        # "An appointment is required" or "An appointment is available". Leaving blank as this information
+        # will likely need phone bankers and/or web team to find availability
+        availability=None,
+        inventory=_get_inventory(site),
+        access=None,
+        parent_organization=None,
+        links=None,
+        notes=None,
+        active=_get_activated(site),
+        source=schema.Source(
+            source="sc_dab_arcgis",
+            id=site["attributes"]["GlobalID"],
+            fetched_from_uri="https://services2.arcgis.com/XZg2efAbaieYAXmu/ArcGIS/rest/services/Vaccine_Locations_DAB_Team/FeatureServer",  # noqa: E501
+            fetched_at=timestamp,
+            data=site,
+        ),
+    )
+
+
+for in_filepath in json_filepaths:
+    filename, _ = os.path.splitext(in_filepath.name)
+    out_filepath = output_dir / f"{filename}.normalized.ndjson"
+
+    logger.info(
+        "normalizing %s => %s",
+        in_filepath,
+        out_filepath,
+    )
+
+    with in_filepath.open() as fin:
+        with out_filepath.open("w") as fout:
+            for site_json in fin:
+                parsed_site = json.loads(site_json)
+
+                normalized_site = _get_normalized_location(
+                    parsed_site, parsed_at_timestamp
+                )
+
+                if not normalized_site:
+                    continue
+
+                json.dump(normalized_site.dict(), fout)
+                fout.write("\n")

--- a/vaccine_feed_ingest/runners/sc/dhec_arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/sc/dhec_arcgis/normalize.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+
+import datetime
+import json
+import os
+import pathlib
+import re
+import sys
+from typing import List, Optional
+
+from pydantic import ValidationError
+from vaccine_feed_ingest_schema import location as schema
+
+from vaccine_feed_ingest.utils.log import getLogger
+from vaccine_feed_ingest.utils.normalize import normalize_phone, normalize_zip
+
+logger = getLogger(__file__)
+
+output_dir = pathlib.Path(sys.argv[1])
+input_dir = pathlib.Path(sys.argv[2])
+
+json_filepaths = input_dir.glob("*.ndjson")
+
+parsed_at_timestamp = datetime.datetime.utcnow().isoformat()
+
+
+def _get_id(site: dict) -> str:
+    data_id = site["attributes"]["GlobalID"]
+
+    # Could parse these from directory traversal, but do not for now to avoid
+    # accidental mutation.
+    site_name = "dhec_arcgis"
+    runner = "sc"
+
+    # Could parse these from the input file name, but do not for now to avoid
+    # accidental mutation.
+    arcgis = "4edb42495ae545d58d378e3127c1afeb"
+    layer = 0
+
+    return f"{runner}_{site_name}:{arcgis}_{layer}_{data_id}"
+
+
+# This currently tosses any address if it doesn't have a street address or zip because
+# the schema doesn't allow optionals for those
+def _get_address(site: dict) -> Optional[schema.Address]:
+    zipc = normalize_zip(site["attributes"]["SiteZip"])
+
+    return schema.Address(
+        street1=site["attributes"]["SiteAddress"],
+        street2=site["attributes"]["SiteAddressDetail"],
+        city=site["attributes"]["SiteCity"],
+        state="SC",
+        zip=zipc,
+    )
+
+
+def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:
+    contacts = []
+    if site["attributes"]["SitePhone"]:
+        for phone in normalize_phone(site["attributes"]["SitePhone"]):
+            contacts.append(phone)
+
+    # Contacts seems to be a free text field where people usually enter emails but also sometimes
+    # other stuff like numbers, hours of operation, etc
+    if site["attributes"]["Contact"]:
+        if "@" in site["attributes"]["Contact"]:
+            contacts.append(
+                schema.Contact(
+                    contact_type="general", email=site["attributes"]["Contact"]
+                )
+            )
+        else:
+            contacts.append(
+                schema.Contact(
+                    contact_type="general", other=site["attributes"]["Contact"]
+                )
+            )
+
+    url = site["attributes"]["URL"]
+    if url:
+        url = url if "http" in url else "https://" + url
+        URL_RE = re.compile(
+            r"^((https?):\/\/)(www.)?[a-z0-9]+\.[a-z]+(\/?[a-zA-Z0-9#]+\/?)*$"
+        )
+        valid = URL_RE.match(url)
+        if valid:
+            contacts.append(schema.Contact(contact_type="general", website=url))
+
+    if len(contacts) > 0:
+        return contacts
+
+    return None
+
+
+# Using "Appointments" field though unclear whether this should be interpreted as
+# "An appointment is required" or "An appointment is available"
+def _get_activated(site: dict) -> bool:
+    if site["attributes"]["Activated1"] == "No":
+        return False
+    else:
+        return True
+
+
+def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
+    if site["attributes"]["V_Manufacturer"]:
+        vaccines_field = map(
+            lambda str: str.strip(),
+            site["attributes"]["V_Manufacturer"].lower().split(","),
+        )
+
+        potentials = {
+            "pzr": schema.Vaccine(vaccine="pfizer_biontech"),
+            "pfr": schema.Vaccine(vaccine="pfizer_biontech"),
+            "pfizer": schema.Vaccine(vaccine="pfizer_biontech"),
+            "mod": schema.Vaccine(vaccine="moderna"),
+            "moderna": schema.Vaccine(vaccine="moderna"),
+            "jj": schema.Vaccine(vaccine="johnson_johnson_janssen"),
+            "jjj": schema.Vaccine(vaccine="johnson_johnson_janssen"),
+        }
+
+        inventory = []
+
+        for vf in vaccines_field:
+            try:
+                inventory.append(potentials[vf])
+            except KeyError as e:
+                logger.error("Unexpected vaccine type: %s", e)
+
+        if len(inventory) > 0:
+            return inventory
+
+    return None
+
+
+def _get_normalized_location(
+    site: dict, timestamp: str
+) -> Optional[schema.NormalizedLocation]:
+    if site["attributes"] is None:
+        logger.error(
+            "Cannot normalize site data without an 'attributes' field: %s", site
+        )
+        return None
+    name = site["attributes"]["loc_name"]
+    if name is None:
+        logger.error(
+            "Cannot normalize site data without an 'attributes.loc_name' field: %s",
+            site,
+        )
+        return None
+    if len(name) > 256:
+        logger.error("Site name must have 256 characters or fewer; ignoring %s", name)
+        return None
+
+    # Contact parsing for this site is a little flaky. Ensure that a bug for
+    # a single entry does not halt overall scraping.
+    try:
+        contacts = _get_contacts(site)
+    except ValidationError:
+        logger.warning(
+            "Errored while trying to parse contact from %s, %s, or %s",
+            site["attributes"]["SitePhone"],
+            site["attributes"]["Contact"],
+            site["attributes"]["URL"],
+        )
+        contacts = None
+
+    return schema.NormalizedLocation(
+        id=_get_id(site),
+        name=name,
+        address=_get_address(site),
+        location=schema.LatLng(
+            latitude=site["geometry"]["y"],
+            longitude=site["geometry"]["x"],
+        ),
+        contact=contacts,
+        languages=None,
+        opening_dates=None,
+        opening_hours=None,
+        # There is an "Appointments" field in the data though it is unclear whether this should be interpreted as
+        # "An appointment is required" or "An appointment is available". Leaving blank as this information
+        # will likely need phone bankers and/or web team to find availability
+        availability=None,
+        inventory=_get_inventory(site),
+        access=None,
+        parent_organization=None,
+        links=None,
+        notes=None,
+        active=_get_activated(site),
+        source=schema.Source(
+            source="sc_dhec_arcgis",
+            id=site["attributes"]["GlobalID"],
+            fetched_from_uri="https://services2.arcgis.com/XZg2efAbaieYAXmu/ArcGIS/rest/services/Vaccine_Locations_DHEC_Sharing/FeatureServer",  # noqa: E501
+            fetched_at=timestamp,
+            data=site,
+        ),
+    )
+
+
+for in_filepath in json_filepaths:
+    filename, _ = os.path.splitext(in_filepath.name)
+    out_filepath = output_dir / f"{filename}.normalized.ndjson"
+
+    logger.info(
+        "normalizing %s => %s",
+        in_filepath,
+        out_filepath,
+    )
+
+    with in_filepath.open() as fin:
+        with out_filepath.open("w") as fout:
+            for site_json in fin:
+                parsed_site = json.loads(site_json)
+
+                normalized_site = _get_normalized_location(
+                    parsed_site, parsed_at_timestamp
+                )
+
+                if not normalized_site:
+                    continue
+
+                json.dump(normalized_site.dict(), fout)
+                fout.write("\n")

--- a/vaccine_feed_ingest/runners/sc/nomad_arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/sc/nomad_arcgis/normalize.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+
+import datetime
+import json
+import os
+import pathlib
+import re
+import sys
+from typing import List, Optional
+
+from pydantic import ValidationError
+from vaccine_feed_ingest_schema import location as schema
+
+from vaccine_feed_ingest.utils.log import getLogger
+from vaccine_feed_ingest.utils.normalize import normalize_phone, normalize_zip
+
+logger = getLogger(__file__)
+
+output_dir = pathlib.Path(sys.argv[1])
+input_dir = pathlib.Path(sys.argv[2])
+
+json_filepaths = input_dir.glob("*.ndjson")
+
+parsed_at_timestamp = datetime.datetime.utcnow().isoformat()
+
+
+def _get_id(site: dict) -> str:
+    data_id = site["attributes"]["GlobalID"]
+
+    # Could parse these from directory traversal, but do not for now to avoid
+    # accidental mutation.
+    site_name = "nomad_arcgis"
+    runner = "sc"
+
+    # Could parse these from the input file name, but do not for now to avoid
+    # accidental mutation.
+    arcgis = "1256d5b3c554475099c24b98326e3b36"
+    layer = 0
+
+    return f"{runner}_{site_name}:{arcgis}_{layer}_{data_id}"
+
+
+# This currently tosses any address if it doesn't have a street address or zip because
+# the schema doesn't allow optionals for those
+def _get_address(site: dict) -> Optional[schema.Address]:
+    zipc = normalize_zip(site["attributes"]["SiteZip"])
+
+    return schema.Address(
+        street1=site["attributes"]["SiteAddress"],
+        street2=site["attributes"]["SiteAddressDetail"],
+        city=site["attributes"]["SiteCity"],
+        state="SC",
+        zip=zipc,
+    )
+
+
+def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:
+    contacts = []
+    if site["attributes"]["SitePhone"]:
+        for phone in normalize_phone(site["attributes"]["SitePhone"]):
+            contacts.append(phone)
+
+    # Contacts seems to be a free text field where people usually enter emails but also sometimes
+    # other stuff like numbers, hours of operation, etc
+    if site["attributes"]["Contact"]:
+        if "@" in site["attributes"]["Contact"]:
+            contacts.append(
+                schema.Contact(
+                    contact_type="general", email=site["attributes"]["Contact"]
+                )
+            )
+        else:
+            contacts.append(
+                schema.Contact(
+                    contact_type="general", other=site["attributes"]["Contact"]
+                )
+            )
+
+    url = site["attributes"]["URL"]
+    if url:
+        url = url if "http" in url else "https://" + url
+        URL_RE = re.compile(
+            r"^((https?):\/\/)(www.)?[a-z0-9]+\.[a-z]+(\/?[a-zA-Z0-9#]+\/?)*$"
+        )
+        valid = URL_RE.match(url)
+        if valid:
+            contacts.append(schema.Contact(contact_type="general", website=url))
+
+    if len(contacts) > 0:
+        return contacts
+
+    return None
+
+
+# Using "Appointments" field though unclear whether this should be interpreted as
+# "An appointment is required" or "An appointment is available"
+def _get_activated(site: dict) -> bool:
+    if site["attributes"]["Activated1"] == "No":
+        return False
+    else:
+        return True
+
+
+def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
+    if site["attributes"]["V_Manufacturer"]:
+        vaccines_field = map(
+            lambda str: str.strip(),
+            site["attributes"]["V_Manufacturer"].lower().split(","),
+        )
+
+        potentials = {
+            "pzr": schema.Vaccine(vaccine="pfizer_biontech"),
+            "pfr": schema.Vaccine(vaccine="pfizer_biontech"),
+            "pfizer": schema.Vaccine(vaccine="pfizer_biontech"),
+            "mod": schema.Vaccine(vaccine="moderna"),
+            "moderna": schema.Vaccine(vaccine="moderna"),
+            "jj": schema.Vaccine(vaccine="johnson_johnson_janssen"),
+            "jjj": schema.Vaccine(vaccine="johnson_johnson_janssen"),
+        }
+
+        inventory = []
+
+        for vf in vaccines_field:
+            try:
+                inventory.append(potentials[vf])
+            except KeyError as e:
+                logger.error("Unexpected vaccine type: %s", e)
+
+        if len(inventory) > 0:
+            return inventory
+
+    return None
+
+
+def _get_normalized_location(
+    site: dict, timestamp: str
+) -> Optional[schema.NormalizedLocation]:
+    if site["attributes"] is None:
+        logger.error(
+            "Cannot normalize site data without an 'attributes' field: %s", site
+        )
+        return None
+    name = site["attributes"]["loc_name"]
+    if name is None:
+        logger.error(
+            "Cannot normalize site data without an 'attributes.loc_name' field: %s",
+            site,
+        )
+        return None
+    if len(name) > 256:
+        logger.error("Site name must have 256 characters or fewer; ignoring %s", name)
+        return None
+
+    # Contact parsing for this site is a little flaky. Ensure that a bug for
+    # a single entry does not halt overall scraping.
+    try:
+        contacts = _get_contacts(site)
+    except ValidationError:
+        logger.warning(
+            "Errored while trying to parse contact from %s, %s, or %s",
+            site["attributes"]["SitePhone"],
+            site["attributes"]["Contact"],
+            site["attributes"]["URL"],
+        )
+        contacts = None
+
+    return schema.NormalizedLocation(
+        id=_get_id(site),
+        name=name,
+        address=_get_address(site),
+        location=schema.LatLng(
+            latitude=site["geometry"]["y"],
+            longitude=site["geometry"]["x"],
+        ),
+        contact=contacts,
+        languages=None,
+        opening_dates=None,
+        opening_hours=None,
+        # There is an "Appointments" field in the data though it is unclear whether this should be interpreted as
+        # "An appointment is required" or "An appointment is available". Leaving blank as this information
+        # will likely need phone bankers and/or web team to find availability
+        availability=None,
+        inventory=_get_inventory(site),
+        access=None,
+        parent_organization=None,
+        links=None,
+        notes=None,
+        active=_get_activated(site),
+        source=schema.Source(
+            source="sc_nomad_arcgis",
+            id=site["attributes"]["GlobalID"],
+            fetched_from_uri="https://services2.arcgis.com/XZg2efAbaieYAXmu/ArcGIS/rest/services/Vaccine_Locations_nomad/FeatureServer",  # noqa: E501
+            fetched_at=timestamp,
+            data=site,
+        ),
+    )
+
+
+for in_filepath in json_filepaths:
+    filename, _ = os.path.splitext(in_filepath.name)
+    out_filepath = output_dir / f"{filename}.normalized.ndjson"
+
+    logger.info(
+        "normalizing %s => %s",
+        in_filepath,
+        out_filepath,
+    )
+
+    with in_filepath.open() as fin:
+        with out_filepath.open("w") as fout:
+            for site_json in fin:
+                parsed_site = json.loads(site_json)
+
+                normalized_site = _get_normalized_location(
+                    parsed_site, parsed_at_timestamp
+                )
+
+                if not normalized_site:
+                    continue
+
+                json.dump(normalized_site.dict(), fout)
+                fout.write("\n")

--- a/vaccine_feed_ingest/runners/sc/nomad_arcgis/normalize.py
+++ b/vaccine_feed_ingest/runners/sc/nomad_arcgis/normalize.py
@@ -132,6 +132,15 @@ def _get_inventory(site: dict) -> Optional[List[schema.Vaccine]]:
     return None
 
 
+def _get_published_at(site: dict) -> Optional[str]:
+    date_with_millis = site["attributes"]["EditDate"]
+    if date_with_millis:
+        date = datetime.datetime.fromtimestamp(date_with_millis / 1000)  # Drop millis
+        return date.isoformat()
+
+    return None
+
+
 def _get_normalized_location(
     site: dict, timestamp: str
 ) -> Optional[schema.NormalizedLocation]:
@@ -191,6 +200,7 @@ def _get_normalized_location(
             id=site["attributes"]["GlobalID"],
             fetched_from_uri="https://services2.arcgis.com/XZg2efAbaieYAXmu/ArcGIS/rest/services/Vaccine_Locations_nomad/FeatureServer",  # noqa: E501
             fetched_at=timestamp,
+            published_at=_get_published_at(site),
             data=site,
         ),
     )


### PR DESCRIPTION


| Key Details |
|-|
| Resolves #759 Resolves #757 Resolves #756 |
State: sc |
Site: dab_arcgis shec_arcgis and nomad_arcgis |

## Notes
turns out theyre all pretty much the same as the existing arcgis site. i think nomad might have a few more sites (just from looking at the number of lines in the parsed output) but i didnt want to assume there are no differences though so might as well grab them all.

All use the same normalizer except for nomad which has a slight change to include the date it was published (and of course different source names and urls)


### Further improvement suggestions 
Since the fetch stage's `.yml` supports multiple serviceItemID's all of these can easily be merged with the only block on this being some way to associate the correct source names and urls with the right data.

This could be an if-else chain based on the service Item ID, but it seems to make more sense to add a way to add these values to the yml and pass them through since that may be helpful for anyone trying to get from service item id back to the original arcgis map that it came from.


## Data sample
<!-- copy the first several lines of output data into the codeblock below. Feel free to change the block type -->
```json
{"id": "sc_nomad_arcgis:1256d5b3c554475099c24b98326e3b36_0_b456ea0b-db46-42f4-9bbe-3df1a38e4fa8", "name": "Carolina Cataract and Vision Center", "address": {"street1": "137 gateway drive", "street2": null, "city": "Ladson", "state": "SC", "zip": "29456"}, "location": {"latitude": 32.997858505756824, "longitude": -80.09152585378803}, "contact": null, "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": null, "active": true, "source": {"source": "sc_nomad_arcgis", "id": "b456ea0b-db46-42f4-9bbe-3df1a38e4fa8", "fetched_from_uri": "https://services2.arcgis.com/XZg2efAbaieYAXmu/ArcGIS/rest/services/Vaccine_Locations_nomad/FeatureServer", "fetched_at": "2021-06-16T23:01:59.865422", "published_at": "2021-01-25T10:01:37", "data": {"attributes": {"Activated1": "Yes", "Appointments": "No", "Contact": null, "CreationDate": 1611182038000, "Creator": "watsonem", "EditDate": 1611597697000, "Editor": "OyerZDHEC", "GlobalID": "b456ea0b-db46-42f4-9bbe-3df1a38e4fa8", "Loc_ID": 845, "OBJECTID": 1, "Phone_Sec": null, "Region": "Lowcountry", "SiteAddress": "137 gateway drive", "SiteAddressDetail": null, "SiteCity": "Ladson", "SitePhone": "", "SiteState": "SC", "SiteZip": "29456", "Status": "Approved", "URL": null, "V_Manufacturer": null, "layer_id": 0, "loc_admin_city": null, "loc_admin_phone": null, "loc_admin_state": null, "loc_admin_street1": null, "loc_admin_street2": null, "loc_admin_zip": null, "loc_covid_id": null, "loc_name": "Carolina Cataract and Vision Center", "loc_ship_city": "Ladson", "loc_ship_phone": "843-797-3676", "loc_ship_state": "SC", "loc_ship_street1": "137 gateway drive", "loc_ship_street2": null, "loc_ship_zip": 29456, "loc_type1": "Medical practice \u2013 other specialty", "ref_ID": 954, "service_item_id": "1256d5b3c554475099c24b98326e3b36", "vfc_text": "SCA918009", "vtrcks_ID": 40208317}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -80.09152585378803, "y": 32.997858505756824}}}}
{"id": "sc_nomad_arcgis:1256d5b3c554475099c24b98326e3b36_0_220d6067-6ceb-4655-93ef-b5ed05e84c49", "name": "Center for Primary Care, PC", "address": {"street1": "105 E Hugh St", "street2": null, "city": "North Augusta", "state": "SC", "zip": "29841"}, "location": {"latitude": 33.51771994180649, "longitude": -81.95652331218946}, "contact": null, "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": null, "active": false, "source": {"source": "sc_nomad_arcgis", "id": "220d6067-6ceb-4655-93ef-b5ed05e84c49", "fetched_from_uri": "https://services2.arcgis.com/XZg2efAbaieYAXmu/ArcGIS/rest/services/Vaccine_Locations_nomad/FeatureServer", "fetched_at": "2021-06-16T23:01:59.865422", "published_at": "2021-01-25T10:01:37", "data": {"attributes": {"Activated1": "No", "Appointments": "No", "Contact": null, "CreationDate": 1611182038000, "Creator": "watsonem", "EditDate": 1611597697000, "Editor": "OyerZDHEC", "GlobalID": "220d6067-6ceb-4655-93ef-b5ed05e84c49", "Loc_ID": 813, "OBJECTID": 2, "Phone_Sec": null, "Region": "Midlands", "SiteAddress": "105 E Hugh St", "SiteAddressDetail": null, "SiteCity": "North Augusta", "SitePhone": "", "SiteState": "SC", "SiteZip": "29841", "Status": "Approved", "URL": null, "V_Manufacturer": null, "layer_id": 0, "loc_admin_city": null, "loc_admin_phone": null, "loc_admin_state": null, "loc_admin_street1": null, "loc_admin_street2": null, "loc_admin_zip": null, "loc_covid_id": null, "loc_name": "Center for Primary Care, PC", "loc_ship_city": "North Augusta", "loc_ship_phone": "706-279-6800", "loc_ship_state": "SC", "loc_ship_street1": "105 E Hugh St", "loc_ship_street2": null, "loc_ship_zip": 29841, "loc_type1": "Medical practice \u2013 family medicine", "ref_ID": 955, "service_item_id": "1256d5b3c554475099c24b98326e3b36", "vfc_text": "SCA502005", "vtrcks_ID": 40117843}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -81.95652331218946, "y": 33.51771994180649}}}}
{"id": "sc_nomad_arcgis:1256d5b3c554475099c24b98326e3b36_0_6ef35196-c3f4-4464-a572-17f00f83c669", "name": "Seneca Health and Wellness Center/Cigna Onsite Health, LLC", "address": {"street1": "125 Lila Doyle Drive", "street2": null, "city": "Seneca", "state": "SC", "zip": "29678"}, "location": {"latitude": 34.69404697221887, "longitude": -82.98411190682685}, "contact": null, "languages": null, "opening_dates": null, "opening_hours": null, "availability": null, "inventory": null, "access": null, "parent_organization": null, "links": null, "notes": null, "active": true, "source": {"source": "sc_nomad_arcgis", "id": "6ef35196-c3f4-4464-a572-17f00f83c669", "fetched_from_uri": "https://services2.arcgis.com/XZg2efAbaieYAXmu/ArcGIS/rest/services/Vaccine_Locations_nomad/FeatureServer", "fetched_at": "2021-06-16T23:01:59.865422", "published_at": "2021-01-25T10:01:37", "data": {"attributes": {"Activated1": "Yes", "Appointments": "No", "Contact": null, "CreationDate": 1611182038000, "Creator": "watsonem", "EditDate": 1611597697000, "Editor": "OyerZDHEC", "GlobalID": "6ef35196-c3f4-4464-a572-17f00f83c669", "Loc_ID": 782, "OBJECTID": 3, "Phone_Sec": null, "Region": "Upstate", "SiteAddress": "125 Lila Doyle Drive", "SiteAddressDetail": null, "SiteCity": "Seneca", "SitePhone": "", "SiteState": "SC", "SiteZip": "29678", "Status": "Approved", "URL": null, "V_Manufacturer": null, "layer_id": 0, "loc_admin_city": null, "loc_admin_phone": null, "loc_admin_state": null, "loc_admin_street1": null, "loc_admin_street2": null, "loc_admin_zip": null, "loc_covid_id": null, "loc_name": "Seneca Health and Wellness Center/Cigna Onsite Health, LLC", "loc_ship_city": "Seneca", "loc_ship_phone": "864-324-7969", "loc_ship_state": "SC", "loc_ship_street1": "125 Lila Doyle Drive", "loc_ship_street2": null, "loc_ship_zip": 29678, "loc_type1": "Health center \u2013 occupational", "ref_ID": 956, "service_item_id": "1256d5b3c554475099c24b98326e3b36", "vfc_text": "SCA937006", "vtrcks_ID": 40226365}, "geometry": {"spatialReference": {"latestWkid": 4326, "wkid": 4326}, "x": -82.98411190682685, "y": 34.69404697221887}}}}
```

## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
