### PR TITLE
Audit giscorps to fix incorrect data and make sure it is pulling in every field

### DIFF
--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -195,6 +195,9 @@ def _get_opening_dates(site: dict) -> Optional[List[schema.OpenDate]]:
     if end_date:
         end_date = datetime.datetime.fromtimestamp(end_date / 1000)
 
+    if start_date and end_date and start_date > end_date:
+        return None
+
     if start_date or end_date:
         return [schema.OpenDate(opens=start_date, closes=end_date)]
     else:

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -177,7 +177,7 @@ def try_lookup(mapping, value, default, name=None):
 
 
 def _get_published_at(site: dict) -> Optional[str]:
-    date_with_millis = site["attributes"]["CreationDate"]
+    date_with_millis = site["attributes"]["EditDate"]
     if date_with_millis:
         date = datetime.datetime.fromtimestamp(date_with_millis / 1000)  # Drop millis
         return date.isoformat()

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -94,7 +94,6 @@ def sanitize_url(url):
 
 
 def _get_notes(site: dict) -> Optional[List[str]]:
-
     notes = []
     if site["attributes"]["Instructions"]:
         notes.append(site["attributes"]["Instructions"])
@@ -127,9 +126,7 @@ def _get_active(site: dict) -> Optional[bool]:
     # end date may be important to check to determine if the site is historical or current. see docs on these fields at https://docs.google.com/document/d/1xqZDHtkNHfelez2Rm3mLAKTwz7gjCAMJaMKK_RxK8F8/edit#
         # these fields are notcurrently  supported by the VTS schema
 
-    # start_date = site["attributes"].get("start_date")
-
-    # end_date = site["attributes"].get("end_date")
+   
 
     status = site["attributes"].get("status")
 
@@ -146,7 +143,7 @@ def _get_active(site: dict) -> Optional[bool]:
 
 def _get_access(site: dict) -> Optional[List[str]]:
     drive = site["attributes"].get("drive_through")
-    drive_bool = drive is not None
+    drive_bool = drive is not None and drive == "Yes"
 
     # walk = site["attributes"].get("drive_through")
     # walk_bool = drive is not None

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -124,9 +124,7 @@ def _get_opening_hours(site):
 
 def _get_active(site: dict) -> Optional[bool]:
     # end date may be important to check to determine if the site is historical or current. see docs on these fields at https://docs.google.com/document/d/1xqZDHtkNHfelez2Rm3mLAKTwz7gjCAMJaMKK_RxK8F8/edit#
-        # these fields are notcurrently  supported by the VTS schema
-
-   
+    # these fields are notcurrently  supported by the VTS schema
 
     status = site["attributes"].get("status")
 
@@ -192,10 +190,10 @@ def _get_opening_dates(site: dict) -> Optional[List[schema.OpenDate]]:
     end_date = site["attributes"].get("end_date")
 
     if start_date:
-        start_date = datetime.datetime.fromtimestamp(start_date/1000)
+        start_date = datetime.datetime.fromtimestamp(start_date / 1000)
 
     if end_date:
-        end_date = datetime.datetime.fromtimestamp(end_date/1000)
+        end_date = datetime.datetime.fromtimestamp(end_date / 1000)
 
     if start_date or end_date:
         return [schema.OpenDate(opens=start_date, closes=end_date)]

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -102,6 +102,9 @@ def _get_notes(site: dict) -> Optional[List[str]]:
     if site.get("opening_hours_notes"):
         notes.append(site["opening_hours_notes"])
 
+    if comments := site.get("comments"):
+        notes.append(comments)
+
     if notes != []:
         return notes
 

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -347,6 +347,9 @@ def _get_address(site):
 
 def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLocation:
 
+    if site.get("offers_vaccine") == "No":
+        return None
+
     return schema.NormalizedLocation(
         id=f"{SOURCE_NAME}:{_get_id(site)}",
         name=site["attributes"]["name"],

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -124,7 +124,11 @@ def _get_opening_hours(site):
 
 
 def _get_active(site: dict) -> Optional[bool]:
-    # end date may be important to check to determine if the site is historicle or current but i dont really feel like digging through the docs rn. see https://github.com/CAVaccineInventory/vaccine-feed-ingest/pull/119 for links that eventually lead to specs on the
+    # end date may be important to check to determine if the site is historical or current. see docs on these fields at https://docs.google.com/document/d/1xqZDHtkNHfelez2Rm3mLAKTwz7gjCAMJaMKK_RxK8F8/edit#
+        # these fields are notcurrently  supported by the VTS schema
+
+    # start_date = site["attributes"].get("start_date")
+
     # end_date = site["attributes"].get("end_date")
 
     status = site["attributes"].get("status")
@@ -345,6 +349,7 @@ def _get_address(site):
         return None
 
 
+# the schema for the incoming data is documented at https://docs.google.com/document/d/1xqZDHtkNHfelez2Rm3mLAKTwz7gjCAMJaMKK_RxK8F8/edit#
 def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLocation:
 
     if site.get("offers_vaccine") == "No":

--- a/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
+++ b/vaccine_feed_ingest/runners/us/giscorps_vaccine_providers/normalize.py
@@ -189,6 +189,23 @@ def _get_published_at(site: dict) -> Optional[str]:
     return None
 
 
+def _get_opening_dates(site: dict) -> Optional[List[schema.OpenDate]]:
+    start_date = site["attributes"].get("start_date")
+
+    end_date = site["attributes"].get("end_date")
+
+    if start_date:
+        start_date = datetime.datetime.fromtimestamp(start_date/1000)
+
+    if end_date:
+        end_date = datetime.datetime.fromtimestamp(end_date/1000)
+
+    if start_date or end_date:
+        return [schema.OpenDate(opens=start_date, closes=end_date)]
+    else:
+        return None
+
+
 def try_get_list(lis, index, default=None):
     if lis is None:
         return default
@@ -362,7 +379,7 @@ def _get_normalized_location(site: dict, timestamp: str) -> schema.NormalizedLoc
         location=try_get_lat_long(site),
         contact=_get_contacts(site),
         languages=None,
-        opening_dates=None,
+        opening_dates=_get_opening_dates(site),
         opening_hours=_get_opening_hours(site),
         availability=_get_availability(site),
         inventory=None,


### PR DESCRIPTION
# audit us/giscorps_vaccine_providers

## Notes
Go through and compare the behavior of the normalizer with the fields available from the parser to double check that every usable fields is being normalized.

Changes made:
- use the `EditDate` field as the publish date since that reflects the last time changes were made to this entry at the source
- ignore entries where `offers_vaccine` is "No"
- normalize `start_date` and `end_date` into the `opening_dates` schema entry
- fix incorrect normalization of drive through data. before it was normalizing both `No` and `Yes` to a drive through value of `True`. so yeah past me who wrote this was not very smart


## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
