### PR TITLE
Fix me gov validation error with urls

### DIFF
--- a/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
@@ -75,8 +75,7 @@ def _get_contacts(site: dict) -> List[schema.Contact]:
     website_matches = re.search('href="(http.*)"', scheduling_info_raw)
     if website_matches:
         website = website_matches.group(1).split(" ")[0]
-        if website.startswith("https://houltonregional.org"):
-            website = website.replace('"', "")
+        website = website.replace('"', "") # remove quote marks from urls
         website = normalize_url(website)
     else:
         website = None

--- a/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
@@ -10,8 +10,8 @@ from typing import List, Optional
 from vaccine_feed_ingest_schema import location as schema
 
 from vaccine_feed_ingest.utils.log import getLogger
-from vaccine_feed_ingest.utils.parse import location_id_from_name
 from vaccine_feed_ingest.utils.normalize import normalize_url
+from vaccine_feed_ingest.utils.parse import location_id_from_name
 
 logger = getLogger(__file__)
 
@@ -76,7 +76,7 @@ def _get_contacts(site: dict) -> List[schema.Contact]:
     if website_matches:
         website = website_matches.group(1).split(" ")[0]
         if website.startswith("https://houltonregional.org"):
-            website = website.replace("\"", "")
+            website = website.replace('"', "")
         website = normalize_url(website)
     else:
         website = None

--- a/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
@@ -75,7 +75,7 @@ def _get_contacts(site: dict) -> List[schema.Contact]:
     website_matches = re.search('href="(http.*)"', scheduling_info_raw)
     if website_matches:
         website = website_matches.group(1).split(" ")[0]
-        website = website.replace('"', "") # remove quote marks from urls
+        website = website.replace('"', "")  # remove quote marks from urls
         website = normalize_url(website)
     else:
         website = None

--- a/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
+++ b/vaccine_feed_ingest/runners/me/maine_gov/normalize.py
@@ -11,6 +11,7 @@ from vaccine_feed_ingest_schema import location as schema
 
 from vaccine_feed_ingest.utils.log import getLogger
 from vaccine_feed_ingest.utils.parse import location_id_from_name
+from vaccine_feed_ingest.utils.normalize import normalize_url
 
 logger = getLogger(__file__)
 
@@ -74,6 +75,9 @@ def _get_contacts(site: dict) -> List[schema.Contact]:
     website_matches = re.search('href="(http.*)"', scheduling_info_raw)
     if website_matches:
         website = website_matches.group(1).split(" ")[0]
+        if website.startswith("https://houltonregional.org"):
+            website = website.replace("\"", "")
+        website = normalize_url(website)
     else:
         website = None
 


### PR DESCRIPTION
# me/maine_gov

| Key Details |
|-|
| related to: https://discord.com/channels/799147121357881364/808515907679682590/859617354622042123 |
State: me |
Site: maine_gov |

## Notes
Fix validation so it can handle the single URL that contains a `"` and breaks the validation

## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
