### PR TITLE
rename ri prepmod so its clear that it comes from RI

### DIFF
--- a/vaccine_feed_ingest/runners/ri/prepmod/fetch.yml
+++ b/vaccine_feed_ingest/runners/ri/prepmod/fetch.yml
@@ -1,5 +1,5 @@
 ---
 state: ri
-site: prepmod
+site: ri_prepmod
 parser: prepmod
 url: https://www.vaccinateri.org/


### PR DESCRIPTION
this is a possibly disruptive change to hopefully make errors involving this scraper easier to track down

if no other scrapers are named `prepmod` then this is probably not worth the disruption to fix