### PR TITLE
Mn gov url fixups

### DIFF
--- a/vaccine_feed_ingest/runners/mn/gov/normalize.py
+++ b/vaccine_feed_ingest/runners/mn/gov/normalize.py
@@ -54,7 +54,7 @@ def _cleanup_url(url):
         return None
 
     url = re.sub(r"^(https?)\/:([^\/:].*)", r"\g<1>://\g<2>", url)
-    url = re.sub(r"^https:/t", "https://t", url)  # fix typos
+    url = re.sub(r"^(https?:\/)([^\/].*)", r"\g<1>/\g<2>", url)
 
     return url
 

--- a/vaccine_feed_ingest/runners/mn/gov/normalize.py
+++ b/vaccine_feed_ingest/runners/mn/gov/normalize.py
@@ -48,10 +48,6 @@ def _get_id(site: dict) -> str:
 def _cleanup_url(url):
     if not url:
         return None
-    # if "@" in url:
-    #     # Some of these are email addresses.
-    #     # Skipping those for now.
-    #     return None
     if " " in url.strip():
         # url contains spaces after stripping the leading and trailing ones
         # it must be an invalid URL
@@ -59,9 +55,6 @@ def _cleanup_url(url):
 
     url = re.sub(r"^https/:", "https://", url)  # fix typos
     url = re.sub(r"^https:/t", "https://t", url)  # fix typos
-
-    # if not url.startswith("http"):
-    #     url = "http://" + url
 
     return url
 

--- a/vaccine_feed_ingest/runners/mn/gov/normalize.py
+++ b/vaccine_feed_ingest/runners/mn/gov/normalize.py
@@ -44,6 +44,7 @@ def _get_id(site: dict) -> str:
 
     return f"{runner}_{site_name}:{arcgis}_{layer}_{data_id}"
 
+
 def _cleanup_url(url):
     if not url:
         return None
@@ -54,7 +55,7 @@ def _cleanup_url(url):
     if url == "COVID-19 Vaccine Information - Hennepin Healthcare":
         return None
     print(url)
-    
+
     url = re.sub(r"^https/:", "https://", url)  # fix typos
     url = re.sub(r"^https:/t", "https://t", url)  # fix typos
 

--- a/vaccine_feed_ingest/runners/mn/gov/normalize.py
+++ b/vaccine_feed_ingest/runners/mn/gov/normalize.py
@@ -53,7 +53,7 @@ def _cleanup_url(url):
         # it must be an invalid URL
         return None
 
-    url = re.sub(r"^https/:", "https://", url)  # fix typos
+    url = re.sub(r"^(https?)\/:([^\/:].*)", r"\g<1>://\g<2>", url)
     url = re.sub(r"^https:/t", "https://t", url)  # fix typos
 
     return url

--- a/vaccine_feed_ingest/runners/mn/gov/normalize.py
+++ b/vaccine_feed_ingest/runners/mn/gov/normalize.py
@@ -54,7 +54,6 @@ def _cleanup_url(url):
     #     return None
     if url == "COVID-19 Vaccine Information - Hennepin Healthcare":
         return None
-    print(url)
 
     url = re.sub(r"^https/:", "https://", url)  # fix typos
     url = re.sub(r"^https:/t", "https://t", url)  # fix typos
@@ -72,7 +71,6 @@ def _get_contacts(site: dict) -> Optional[List[schema.Contact]]:
         contacts.append(schema.Contact(phone=phone))
 
     if url := normalize_url(_cleanup_url(site["attributes"]["URL"])):
-        print(url)
         contacts.append(schema.Contact(website=url))
 
     if contacts:

--- a/vaccine_feed_ingest/runners/mn/gov/normalize.py
+++ b/vaccine_feed_ingest/runners/mn/gov/normalize.py
@@ -52,7 +52,9 @@ def _cleanup_url(url):
     #     # Some of these are email addresses.
     #     # Skipping those for now.
     #     return None
-    if url == "COVID-19 Vaccine Information - Hennepin Healthcare":
+    if " " in url.strip():
+        # url contains spaces after stripping the leading and trailing ones
+        # it must be an invalid URL
         return None
 
     url = re.sub(r"^https/:", "https://", url)  # fix typos


### PR DESCRIPTION
## Notes
fix mn_gov url parsing to handle some additional typos (primarily a url with only one forward slash)


## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
