### PR TITLE
fix: resilient to placekey failures

### DIFF
--- a/vaccine_feed_ingest/apis/placekey.py
+++ b/vaccine_feed_ingest/apis/placekey.py
@@ -1,3 +1,4 @@
+from json.decoder import JSONDecodeError
 from typing import Dict, Optional
 
 import diskcache
@@ -128,11 +129,16 @@ class PlacekeyAPI(CachedAPI):
         if not places:
             return result
 
-        responses = self._placekey_api.lookup_placekeys(
-            places,
-            strict_address_match=strict_address_match,
-            strict_name_match=strict_name_match,
-        )
+        responses = None
+        try:
+            responses = self._placekey_api.lookup_placekeys(
+                places,
+                strict_address_match=strict_address_match,
+                strict_name_match=strict_name_match,
+            )
+        except JSONDecodeError:
+            logger.warning("Placekey failed. Continuing...", exc_info=True)
+            return result
 
         if not responses:
             logger.info(


### PR DESCRIPTION
As outlined in [this issue](https://github.com/Placekey/placekey-py/issues/15), the Placekey API has begun experiencing intermittent failures, which cause the python library to fail to parse the response, which present to our code as a `JSONDecodeError`.

Rescue this error and continue processing without Placekey if it occurs.