### PR TITLE
handle missing clinic id in prepmod scrapers

### DIFF
--- a/vaccine_feed_ingest/runners/_shared/parse.py
+++ b/vaccine_feed_ingest/runners/_shared/parse.py
@@ -142,7 +142,7 @@ elif config["parser"] == "prepmod":
                     )
                     clinic_id = find_clinic_id.group(1)
                 else:
-                    clinic_id = "NOTFOUND"
+                    clinic_id = ""
                 data = {
                     "name": name,
                     "date": date,

--- a/vaccine_feed_ingest/runners/_shared/parse.py
+++ b/vaccine_feed_ingest/runners/_shared/parse.py
@@ -136,10 +136,13 @@ elif config["parser"] == "prepmod":
                     _prepmod_find_data_item(parent, "Available Appointments", -1) or 0
                 )
                 special = _prepmod_find_data_item(parent, "Special Instructions", -1)
-                find_clinic_id = EXTRACT_CLINIC_ID.match(
-                    parent.find_next_sibling("div", "map-image").find("img")["src"]
-                )
-                clinic_id = find_clinic_id.group(1)
+                if content := parent.find_next_sibling("div", "map-image").find("img"):
+                    find_clinic_id = EXTRACT_CLINIC_ID.match(
+                        content["src"]
+                    )
+                    clinic_id = find_clinic_id.group(1)
+                else:
+                    clinic_id = "NOTFOUND"
                 data = {
                     "name": name,
                     "date": date,

--- a/vaccine_feed_ingest/runners/_shared/parse.py
+++ b/vaccine_feed_ingest/runners/_shared/parse.py
@@ -137,9 +137,7 @@ elif config["parser"] == "prepmod":
                 )
                 special = _prepmod_find_data_item(parent, "Special Instructions", -1)
                 if content := parent.find_next_sibling("div", "map-image").find("img"):
-                    find_clinic_id = EXTRACT_CLINIC_ID.match(
-                        content["src"]
-                    )
+                    find_clinic_id = EXTRACT_CLINIC_ID.match(content["src"])
                     clinic_id = find_clinic_id.group(1)
                 else:
                     clinic_id = ""


### PR DESCRIPTION
Just a minor change made to handle an edge case discovered in some test data while evaluating the new prepmod APIs

this does not solve any known or currently present issue, just wanted to provide the opportunity to merge a possible improvement. No hard feelings if this doesnt get merged.

## Before Opening a PR
- [X] I tested this using the CLI (e.g., `poetry run vaccine-feed-ingest <state>/<site>`)
- [X] I ran auto-formatting: `poetry run tox -e lint-fix`
